### PR TITLE
SwitchInt & Extern call pointer arguments

### DIFF
--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -112,14 +112,14 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                     v.intv
                         .gamma()
                         .unwrap()
-                        .into_iter()
+                        .iter()
                         .map(|b| targets.target_for_value(*b as _).start_location())
                         .collect()
                 } else if !v.uintv.is_bot() && !v.uintv.is_top() {
                     v.uintv
                         .gamma()
                         .unwrap()
-                        .into_iter()
+                        .iter()
                         .map(|u| targets.target_for_value(*u).start_location())
                         .collect()
                 } else {
@@ -250,7 +250,10 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                     .transfer_intra_call(callee, summary, args, dst, state, location, reads);
             } else if name.contains("{extern#0}") {
                 (
-                    vec![(self.transfer_c_call(callee, args, &mut state, &mut reads), None)],
+                    vec![(
+                        self.transfer_c_call(callee, args, &mut state, &mut reads),
+                        None,
+                    )],
                     CallKind::C,
                 )
             } else if name.contains("{impl#") {

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -108,6 +108,20 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                         .into_iter()
                         .map(|b| targets.target_for_value(b as _).start_location())
                         .collect()
+                } else if !v.intv.is_bot() && !v.intv.is_top() {
+                    v.intv
+                        .gamma()
+                        .unwrap()
+                        .into_iter()
+                        .map(|b| targets.target_for_value(*b as _).start_location())
+                        .collect()
+                } else if !v.uintv.is_bot() && !v.uintv.is_top() {
+                    v.uintv
+                        .gamma()
+                        .unwrap()
+                        .into_iter()
+                        .map(|u| targets.target_for_value(*u).start_location())
+                        .collect()
                 } else {
                     targets
                         .all_targets()


### PR DESCRIPTION
related #6 , fixes #7 

수정 사항:
- SwitchInt의 int(or uint) value 가 top이 아닌 경우에는 해당 값에 따라 target을 정확하게 결정하도록 수정
- C 함수에 포인터를 전달하여 호출하는 경우 해당 지점의 값들을 top으로 수정  



테스트 결과 
- 좌측은 논문 벤치마크 결과, bullet point는 변경의 원인을 나타냄
- master branch에 이미 적용되었던 변경사항 (ex. nullable detection 개선으로 인한 변경사항)은 나타내지 않음


glpk / 58 57 45 → 63 58 51
- Transfer_c_call 수정
    - str2int : may / TP
    - str2num : may / TP
    - _glp_str2num: may / TP
- Location 수정
    - cmir_ineq : may / TP
    - cmir_sep: may / TP
    - _glp_spx_chuzr_harris: may → must / TP
- 메인 머지 후 변경사항
    - glp_read_maxflow: **FN**. nullable location detection 문제 -> 추가적으로 이슈 올려 해결할 예정

gprolog / 61 44 40 → 63 44 42
- Location 수정
    - EnginePl::engine::Get_Prolog_Path : may / TP
    - TopComp::top_comp::Get_Prolog_Path: may / TP

grep / 41 15 26 → 43 16 27
- Location 수정
    - src::grep::get_nondigit_option : may / TP
    - src::grep::context_length_arg : must / TP

mtools / 33 29 18 → 34 31 17
- Transfer_c_call 수정
    - misc::str_to_off_with_end → must / TP
    - misc::str_to_offset_with_end → must / TP
    - charsetConv::dos_to_wchar → may / FN
- Location 수정
    - init::try_device → may / TP
    - init::find_device → may / TP
   
nano / 42 23 29 → 44 23 32
- Location 수정
    - src::utils::parse_line_column → may / TP
    - src::utils::parse_num → may / TP

units / 12 11 8 → 11 8 9
- Transfer_c_call 수정
    - units::extract_interval → may / TP

uucp / 91 70 41 → 87 69 36
- Transfer_c_call 수정
    - unix::status::fsysdep_get_status → may / TN
    - unix::statsb::zsysdep_all_status → may / TN
    - uuconf::vport::uuconf_v2_find_port → may / TP
    