### PR TITLE
Alias analysis for parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,6 +165,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 name = "nopcrat"
 version = "1.0.0"
 dependencies = [
+ "arrayvec",
  "clap",
  "etrace",
  "lazy_static",
@@ -166,8 +173,10 @@ dependencies = [
  "rustfix",
  "serde",
  "serde_json",
+ "smallvec",
  "tracing",
  "tracing-subscriber",
+ "typed-arena",
 ]
 
 [[package]]
@@ -400,6 +409,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ lazy_static = "1.4.0"
 serde = "1.0.189"
 serde_json = "1.0.107"
 rand = "0.8.5"
+typed-arena = "2.0.2"
+arrayvec = { version = "0.7", default-features = false }
+smallvec = "1.8.1"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -913,29 +913,26 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
         let mut indexes = FxHashSet::default();
         let mut visited = FxHashSet::default();
         let mut stack = vec![initial_id];
-        loop {
-            if let Some(callee) = stack.pop() {
-                if !visited.insert(callee) {
-                    continue;
-                }
 
-                let globals = info_map[&callee]
-                    .globals
-                    .iter()
-                    .filter_map(|def_id| {
-                        let local_id = def_id.as_local()?;
-                        let start = globals.get(&local_id).copied()?;
-                        let end = self.pre_context.ends[start];
-                        Some(start..=end)
-                    })
-                    .flatten();
-                indexes.extend(globals);
+        while let Some(callee) = stack.pop() {
+            if !visited.insert(callee) {
+                continue;
+            }
 
-                if let Some(callees) = call_graph.get(&callee) {
-                    stack.extend(callees.iter());
-                }
-            } else {
-                break;
+            let globals = info_map[&callee]
+                .globals
+                .iter()
+                .filter_map(|def_id| {
+                    let local_id = def_id.as_local()?;
+                    let start = globals.get(&local_id).copied()?;
+                    let end = self.pre_context.ends[start];
+                    Some(start..=end)
+                })
+                .flatten();
+            indexes.extend(globals);
+
+            if let Some(callees) = call_graph.get(&callee) {
+                stack.extend(callees.iter());
             }
         }
 

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -901,13 +901,16 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
     ) -> BTreeSet<usize> {
         let mut indexes = FxHashSet::default();
         for callee in callees {
-            let globals = info_map[callee].globals.iter().filter_map(|def_id| {
-                let local_id = def_id.as_local()?;
-                let start = self.pre_context.globals.get(&local_id).copied()?;
-                let end = self.pre_context.ends[start];
-                Some(start..=end)
-            })
-            .flatten();
+            let globals = info_map[callee]
+                .globals
+                .iter()
+                .filter_map(|def_id| {
+                    let local_id = def_id.as_local()?;
+                    let start = self.pre_context.globals.get(&local_id).copied()?;
+                    let end = self.pre_context.ends[start];
+                    Some(start..=end)
+                })
+                .flatten();
             indexes.extend(globals);
         }
 

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -1503,16 +1503,9 @@ impl<'tcx> GlobalVisitor<'tcx> {
 
 impl<'tcx> MVisitor<'tcx> for GlobalVisitor<'tcx> {
     fn visit_const_operand(&mut self, constant: &ConstOperand<'tcx>, _location: Location) {
-        if let Const::Val(value, _ty) = constant.const_ {
-            match value {
-                ConstValue::Scalar(Scalar::Ptr(ptr, _)) => {
-                    if let GlobalAlloc::Static(def_id) =
-                        self.tcx.global_alloc(ptr.provenance.alloc_id())
-                    {
-                        self.globals.insert(def_id);
-                    }
-                }
-                _ => {}
+        if let Const::Val(ConstValue::Scalar(Scalar::Ptr(ptr, _)), _) = constant.const_ {
+            if let GlobalAlloc::Static(def_id) = self.tcx.global_alloc(ptr.provenance.alloc_id()) {
+                self.globals.insert(def_id);
             }
         }
     }

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -173,7 +173,6 @@ pub fn analyze(
     }
 
     let funcs: FxHashSet<_> = call_graph.keys().cloned().collect();
-
     for callees in call_graph.values_mut() {
         callees.retain(|callee| funcs.contains(callee));
     }

--- a/src/ai/domains.rs
+++ b/src/ai/domains.rs
@@ -16,6 +16,7 @@ pub struct AbsState {
     pub local: AbsLocal,
     pub args: AbsArgs,
     pub excludes: MayPathSet,
+    pub alias_excludes: MayPathSet,
     pub reads: MayPathSet,
     pub writes: MustPathSet,
     pub nulls: MustPathSet,
@@ -28,6 +29,7 @@ impl AbsState {
             local: AbsLocal::bot(),
             args: AbsArgs::bot(),
             excludes: MayPathSet::bot(),
+            alias_excludes: MayPathSet::bot(),
             reads: MayPathSet::bot(),
             writes: MustPathSet::bot(),
             nulls: MustPathSet::bot(),
@@ -39,6 +41,7 @@ impl AbsState {
             local: self.local.join(&other.local),
             args: self.args.join(&other.args),
             excludes: self.excludes.join(&other.excludes),
+            alias_excludes: self.alias_excludes.join(&other.alias_excludes),
             reads: self.reads.join(&other.reads),
             writes: self.writes.join(&other.writes),
             nulls: self.nulls.join(&other.nulls),
@@ -50,6 +53,7 @@ impl AbsState {
             local: self.local.widen(&other.local),
             args: self.args.widen(&other.args),
             excludes: self.excludes.widen(&other.excludes),
+            alias_excludes: self.alias_excludes.widen(&other.alias_excludes),
             reads: self.reads.widen(&other.reads),
             writes: self.writes.widen(&other.writes),
             nulls: self.nulls.widen(&other.nulls),
@@ -60,6 +64,7 @@ impl AbsState {
         self.local.ord(&other.local)
             && self.args.ord(&other.args)
             && self.excludes.ord(&other.excludes)
+            && self.alias_excludes.ord(&other.alias_excludes)
             && self.reads.ord(&other.reads)
             && self.writes.ord(&other.writes)
             && self.nulls.ord(&other.nulls)
@@ -112,6 +117,12 @@ impl AbsState {
         let path = AbsPath(vec![i]);
         if !self.reads.contains(&path) && !self.excludes.contains(&path) {
             self.nulls.insert(path)
+        }
+    }
+
+    pub fn add_alias_excludes<I: Iterator<Item = AbsPath>>(&mut self, paths: I) {
+        for path in paths {
+            self.alias_excludes.insert(path);
         }
     }
 }

--- a/src/ai/domains.rs
+++ b/src/ai/domains.rs
@@ -16,7 +16,6 @@ pub struct AbsState {
     pub local: AbsLocal,
     pub args: AbsArgs,
     pub excludes: MayPathSet,
-    pub alias_excludes: MayPathSet,
     pub reads: MayPathSet,
     pub writes: MustPathSet,
     pub nulls: MustPathSet,
@@ -29,7 +28,6 @@ impl AbsState {
             local: AbsLocal::bot(),
             args: AbsArgs::bot(),
             excludes: MayPathSet::bot(),
-            alias_excludes: MayPathSet::bot(),
             reads: MayPathSet::bot(),
             writes: MustPathSet::bot(),
             nulls: MustPathSet::bot(),
@@ -41,7 +39,6 @@ impl AbsState {
             local: self.local.join(&other.local),
             args: self.args.join(&other.args),
             excludes: self.excludes.join(&other.excludes),
-            alias_excludes: self.alias_excludes.join(&other.alias_excludes),
             reads: self.reads.join(&other.reads),
             writes: self.writes.join(&other.writes),
             nulls: self.nulls.join(&other.nulls),
@@ -53,7 +50,6 @@ impl AbsState {
             local: self.local.widen(&other.local),
             args: self.args.widen(&other.args),
             excludes: self.excludes.widen(&other.excludes),
-            alias_excludes: self.alias_excludes.widen(&other.alias_excludes),
             reads: self.reads.widen(&other.reads),
             writes: self.writes.widen(&other.writes),
             nulls: self.nulls.widen(&other.nulls),
@@ -64,7 +60,6 @@ impl AbsState {
         self.local.ord(&other.local)
             && self.args.ord(&other.args)
             && self.excludes.ord(&other.excludes)
-            && self.alias_excludes.ord(&other.alias_excludes)
             && self.reads.ord(&other.reads)
             && self.writes.ord(&other.writes)
             && self.nulls.ord(&other.nulls)
@@ -117,12 +112,6 @@ impl AbsState {
         let path = AbsPath(vec![i]);
         if !self.reads.contains(&path) && !self.excludes.contains(&path) {
             self.nulls.insert(path)
-        }
-    }
-
-    pub fn add_alias_excludes<I: Iterator<Item = AbsPath>>(&mut self, paths: I) {
-        for path in paths {
-            self.alias_excludes.insert(path);
         }
     }
 }

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -149,7 +149,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                 let (args, readss): (Vec<_>, Vec<_>) = args
                     .iter()
                     .map(|arg| (self.transfer_operand(&arg.node, state)))
-                    .collect();
+                    .unzip();
 
                 for reads2 in readss {
                     reads.extend(reads2);
@@ -885,7 +885,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                     let (vs, readss): (Vec<_>, Vec<_>) = fields
                         .iter()
                         .map(|operand| self.transfer_operand(operand, state))
-                        .collect();
+                        .unzip();
                     let v = AbsValue::alpha_list(vs.into_iter().collect());
                     let reads = readss.into_iter().flatten().collect();
                     (v, reads, vec![])
@@ -898,7 +898,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                             let (vs, readss): (Vec<_>, Vec<_>) = fields
                                 .iter()
                                 .map(|operand| self.transfer_operand(operand, state))
-                                .collect();
+                                .unzip();
                             let v = AbsValue::alpha_list(vs.into_iter().collect());
                             let reads = readss.into_iter().flatten().collect();
                             (v, reads, vec![])

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -1439,10 +1439,6 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
             if ptrs.len() == 1 {
                 let ptr = ptrs.first().unwrap();
                 if let AbsBase::Arg(arg) = ptr.base {
-                    if !self.pre_context.strict {
-                        // skip the check for aliases btw parameters
-                        return vec![];
-                    }
                     excludes.remove(&self.ptr_params[arg]);
                 }
             }

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -72,7 +72,7 @@ impl TransferedTerminator {
 #[allow(clippy::only_used_in_recursion)]
 impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
     pub fn transfer_statement(
-        &mut self,
+        &self,
         stmt: &Statement<'tcx>,
         state: &AbsState,
     ) -> (AbsState, BTreeSet<AbsPath>) {

--- a/src/ai/test/labels.rs
+++ b/src/ai/test/labels.rs
@@ -504,7 +504,7 @@ fn test_bitfields() {
         #[derive(BitfieldStruct)]
         struct S {
             #[bitfield(name = \"x\", ty = \"libc::c_uint\", bits = \"0..=0\")]
-            a: [u8; 1],
+            x: [u8; 1],
         }
         unsafe fn f(s: *mut S) -> libc::c_uint {
             (*s).x()
@@ -528,7 +528,7 @@ fn test_bitfields_set() {
         #[derive(BitfieldStruct)]
         struct S {
             #[bitfield(name = \"x\", ty = \"libc::c_uint\", bits = \"0..=0\")]
-            a: [u8; 1],
+            x: [u8; 1],
         }
         unsafe fn f(s: *mut S) {
             (*s).set_x(0)

--- a/src/bin/nopcrat.rs
+++ b/src/bin/nopcrat.rs
@@ -28,6 +28,10 @@ struct Args {
     max_loop_head_states: Option<usize>,
     #[arg(long)]
     no_widening: bool,
+    #[arg(long)]
+    check_global_alias: bool,
+    #[arg(long)]
+    check_param_alias: bool,
 
     #[arg(short, long)]
     transform: bool,
@@ -99,6 +103,8 @@ fn main() {
         function_times: args.function_times,
         dump_sol: args.dump_sol,
         use_sol: args.use_sol,
+        check_global_alias: args.check_global_alias,
+        check_param_alias: args.check_param_alias,
     };
     let analysis_result = if let Some(dump_file) = &args.use_analysis_result {
         let dump_file = File::open(dump_file).unwrap();

--- a/src/bin/nopcrat.rs
+++ b/src/bin/nopcrat.rs
@@ -28,8 +28,6 @@ struct Args {
     max_loop_head_states: Option<usize>,
     #[arg(long)]
     no_widening: bool,
-    #[arg(long)]
-    strict_alias: bool,
 
     #[arg(short, long)]
     transform: bool,
@@ -101,7 +99,6 @@ fn main() {
         function_times: args.function_times,
         dump_sol: args.dump_sol,
         use_sol: args.use_sol,
-        strict_alias: args.strict_alias,
     };
     let analysis_result = if let Some(dump_file) = &args.use_analysis_result {
         let dump_file = File::open(dump_file).unwrap();

--- a/src/bin/nopcrat.rs
+++ b/src/bin/nopcrat.rs
@@ -17,6 +17,10 @@ struct Args {
     dump_analysis_result: Option<PathBuf>,
     #[arg(short, long)]
     use_analysis_result: Option<PathBuf>,
+    #[arg(long)]
+    dump_sol: Option<PathBuf>,
+    #[arg(long)]
+    use_sol: Option<PathBuf>,
 
     #[arg(short, long)]
     verbose: bool,
@@ -24,6 +28,8 @@ struct Args {
     max_loop_head_states: Option<usize>,
     #[arg(long)]
     no_widening: bool,
+    #[arg(long)]
+    strict_alias: bool,
 
     #[arg(short, long)]
     transform: bool,
@@ -93,6 +99,9 @@ fn main() {
         verbose: args.verbose,
         print_functions: args.print_function.into_iter().collect(),
         function_times: args.function_times,
+        dump_sol: args.dump_sol,
+        use_sol: args.use_sol,
+        strict_alias: args.strict_alias,
     };
     let analysis_result = if let Some(dump_file) = &args.use_analysis_result {
         let dump_file = File::open(dump_file).unwrap();

--- a/src/compile_util.rs
+++ b/src/compile_util.rs
@@ -13,7 +13,10 @@ use rustc_errors::{
 use rustc_feature::UnstableFeatures;
 use rustc_hash::FxHashMap;
 use rustc_interface::{create_and_enter_global_ctxt, passes::parse, Config};
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::{
+    mir::{Body, TerminatorKind},
+    ty::TyCtxt
+};
 use rustc_session::{
     config::{CrateType, ErrorOutputType, Input, Options},
     EarlyDiagCtxt,
@@ -305,4 +308,31 @@ fn toolchain_path(home: Option<String>, toolchain: Option<String>) -> Option<Pat
             path
         })
     })
+}
+
+pub fn body_to_str(body: &Body<'_>) -> String {
+    use std::fmt::Write;
+    let mut s = String::new();
+    writeln!(s, "{:?} {{", body.source.instance.def_id()).unwrap();
+    for (bb, bbd) in body.basic_blocks.iter_enumerated() {
+        writeln!(s, "    {:?}:", bb).unwrap();
+        for stmt in &bbd.statements {
+            writeln!(s, "        {:?}", stmt).unwrap();
+        }
+        if !matches!(
+            bbd.terminator().kind,
+            TerminatorKind::Return | TerminatorKind::Assert { .. }
+        ) {
+            writeln!(s, "        {:?}", bbd.terminator().kind).unwrap();
+        }
+    }
+    writeln!(s, "}}").unwrap();
+    s
+}
+
+pub fn body_size(body: &Body<'_>) -> usize {
+    body.basic_blocks
+        .iter()
+        .map(|bbd| bbd.statements.len() + 1)
+        .sum()
 }

--- a/src/compile_util.rs
+++ b/src/compile_util.rs
@@ -15,7 +15,7 @@ use rustc_hash::FxHashMap;
 use rustc_interface::{create_and_enter_global_ctxt, passes::parse, Config};
 use rustc_middle::{
     mir::{Body, TerminatorKind},
-    ty::TyCtxt
+    ty::TyCtxt,
 };
 use rustc_session::{
     config::{CrateType, ErrorOutputType, Input, Options},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ extern crate rustc_type_ir;
 pub mod ai;
 pub mod compile_util;
 pub mod graph;
+pub mod may_analysis;
 pub mod sampling;
 pub mod size;
 pub mod transform;

--- a/src/may_analysis/alloc_finder.rs
+++ b/src/may_analysis/alloc_finder.rs
@@ -1,0 +1,179 @@
+use etrace::some_or;
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hir::{def_id::LocalDefId, ItemKind};
+use rustc_middle::{
+    mir::{Const, Local, Operand, Rvalue, Statement, StatementKind, Terminator, TerminatorKind},
+    ty::{TyCtxt, TyKind},
+};
+
+use crate::*;
+
+pub(super) fn analyze(tcx: TyCtxt<'_>) -> FxHashSet<LocalDefId> {
+    let mut call_graph = FxHashMap::default();
+    let mut assigns = FxHashMap::default();
+    for item_id in tcx.hir_free_items() {
+        let item = tcx.hir_item(item_id);
+        if !matches!(item.kind, ItemKind::Fn { .. }) {
+            continue;
+        }
+        let local_def_id = item_id.owner_id.def_id;
+        let sig = tcx.fn_sig(local_def_id).skip_binder();
+        let output = sig.output().skip_binder();
+        let TyKind::RawPtr(ty, ..) = output.kind() else {
+            continue;
+        };
+        if !ty.is_c_void(tcx) {
+            continue;
+        }
+        let body = tcx.optimized_mir(local_def_id);
+        let mut analyzer = Analyzer::new(tcx);
+        for bbd in body.basic_blocks.iter() {
+            for stmt in &bbd.statements {
+                analyzer.transfer_stmt(stmt);
+            }
+            analyzer.transfer_term(bbd.terminator());
+        }
+        analyzer.remove_address_takens();
+        assigns.insert(local_def_id, analyzer.assigns);
+        call_graph.insert(local_def_id, analyzer.calls);
+    }
+    let fns: FxHashSet<_> = call_graph.keys().copied().collect();
+    for callees in call_graph.values_mut() {
+        callees.retain(|callee| fns.contains(callee));
+    }
+    let (call_graph_sccs, scc_elems) = graph::compute_sccs(&call_graph);
+    let inv_call_graph_sccs = graph::inverse(&call_graph_sccs);
+    let po = graph::post_order(&call_graph_sccs, &inv_call_graph_sccs);
+    let mut alloc_fns = FxHashSet::default();
+    for f in po.iter().flatten().flat_map(|scc| &scc_elems[scc]) {
+        let assigns = &assigns[f];
+        if is_alloc(Local::from_u32(0), assigns, &alloc_fns) {
+            alloc_fns.insert(*f);
+        }
+    }
+    alloc_fns
+}
+
+fn is_alloc(
+    local: Local,
+    assigns: &FxHashMap<Local, FxHashSet<Value>>,
+    alloc_fns: &FxHashSet<LocalDefId>,
+) -> bool {
+    let vs = some_or!(assigns.get(&local), return false);
+    for v in vs {
+        let b = match v {
+            Value::Local(l) => is_alloc(*l, assigns, alloc_fns),
+            Value::IntraCall(def_id) => alloc_fns.contains(def_id),
+            Value::CCall => true,
+        };
+        if b {
+            return true;
+        }
+    }
+    false
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Value {
+    Local(Local),
+    IntraCall(LocalDefId),
+    CCall,
+}
+
+struct Analyzer<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    assigns: FxHashMap<Local, FxHashSet<Value>>,
+    address_takens: FxHashSet<Local>,
+    calls: FxHashSet<LocalDefId>,
+}
+
+impl<'tcx> Analyzer<'tcx> {
+    #[inline]
+    fn new(tcx: TyCtxt<'tcx>) -> Self {
+        Self {
+            tcx,
+            assigns: FxHashMap::default(),
+            address_takens: FxHashSet::default(),
+            calls: FxHashSet::default(),
+        }
+    }
+
+    #[inline]
+    fn remove_address_takens(&mut self) {
+        self.assigns
+            .retain(|local, _| !self.address_takens.contains(local));
+    }
+
+    fn transfer_stmt(&mut self, stmt: &Statement<'tcx>) {
+        let StatementKind::Assign(box (l, r)) = &stmt.kind else {
+            return;
+        };
+        if !l.projection.is_empty() {
+            return;
+        }
+        match r {
+            Rvalue::Use(r) | Rvalue::Cast(_, r, _) => {
+                if let Some(r) = self.transfer_op(r) {
+                    self.assigns.entry(l.local).or_default().insert(r);
+                }
+            }
+            Rvalue::Ref(_, _, r) => {
+                self.address_takens.insert(r.local);
+            }
+            _ => {}
+        }
+    }
+
+    fn transfer_op(&self, op: &Operand<'tcx>) -> Option<Value> {
+        let place = op.place()?;
+        if place.projection.is_empty() {
+            Some(Value::Local(place.local))
+        } else {
+            None
+        }
+    }
+
+    fn transfer_term(&mut self, term: &Terminator<'tcx>) {
+        let TerminatorKind::Call {
+            func, destination, ..
+        } = &term.kind
+        else {
+            return;
+        };
+        if !destination.projection.is_empty() {
+            return;
+        }
+        let constant = some_or!(func.constant(), return);
+        // let ConstantKind::Val(_, ty) = constant.literal else { unreachable!() };
+        let Const::Val(_, ty) = constant.const_ else {
+            unreachable!()
+        };
+        let TyKind::FnDef(def_id, _) = ty.kind() else {
+            unreachable!()
+        };
+        let local_def_id = some_or!(def_id.as_local(), return);
+        let name: Vec<_> = self
+            .tcx
+            .def_path(*def_id)
+            .data
+            .into_iter()
+            .map(|data| data.to_string())
+            .collect();
+        let is_extern = name.iter().any(|s| s.starts_with("{extern#"));
+        if is_extern {
+            let name = name.last().unwrap();
+            if name == "malloc" || name == "calloc" || name == "realloc" {
+                self.assigns
+                    .entry(destination.local)
+                    .or_default()
+                    .insert(Value::CCall);
+            }
+        } else {
+            self.assigns
+                .entry(destination.local)
+                .or_default()
+                .insert(Value::IntraCall(local_def_id));
+            self.calls.insert(local_def_id);
+        }
+    }
+}

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -433,6 +433,7 @@ pub fn deserialize_solutions(arr: &[u8]) -> Solutions {
     solutions
 }
 
+// To filter out the cases where the types of two global indices are not compatible
 fn check_type<'tcx>(
     pre: &PreAnalysisData<'tcx>,
     index1: usize,
@@ -467,6 +468,7 @@ fn check_type<'tcx>(
     }
 }
 
+// Computes the aliasing information for the function parameters
 pub fn compute_alias<'tcx>(
     pre: PreAnalysisData<'tcx>,
     solutions: Solutions,
@@ -496,9 +498,9 @@ pub fn compute_alias<'tcx>(
         let local_def_id = some_or!(def_id.as_local(), continue);
         let mut params = FxHashMap::default();
         let mut locals = HybridBitSet::new_empty(pre.index_info.len());
-        // Set of aliases for the function parameters
+        // Aliases of the function parameters
         let mut fun_alias = HybridBitSet::new_empty(pre.index_info.len());
-        // Map of alias to the set of parameters
+        // Map of an alias candidate to the set of parameters that it may alias
         let mut inv_alias: FxHashMap<_, FxHashSet<_>> = FxHashMap::default();
         // Map of location to set of parameters that may point to the location
         let mut inv_param: FxHashMap<_, FxHashSet<_>> = FxHashMap::default();

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -1,0 +1,1574 @@
+use std::{
+    cell::RefCell,
+    collections::{hash_map::Entry, HashMap, HashSet},
+};
+
+use etrace::some_or;
+use rustc_abi::FieldIdx;
+use rustc_data_structures::graph::{scc::Sccs, DirectedGraph, Successors};
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hir::{def::Res, ItemKind, QPath, TyKind as HirTyKind};
+use rustc_index::{Idx, IndexVec};
+use rustc_middle::{
+    mir::{
+        interpret::{GlobalAlloc, Scalar},
+        visit::Visitor,
+        AggregateKind, BasicBlock, BinOp, Body, Const, ConstValue, Local, LocalDecl, Location,
+        Operand, Place, PlaceElem, Rvalue, Statement, StatementKind, Terminator, TerminatorKind,
+        UnOp,
+    },
+    ty::{Ty, TyCtxt, TyKind},
+};
+use rustc_span::{
+    def_id::{DefId, LocalDefId},
+    source_map::Spanned,
+};
+
+use super::{alloc_finder, bitset::HybridBitSet, ty_shape::*};
+use crate::*;
+
+#[derive(Debug)]
+pub struct BodyItem<'tcx> {
+    local_def_id: LocalDefId,
+    body: &'tcx Body<'tcx>,
+    is_fn: bool,
+}
+
+#[derive(Debug)]
+pub struct PreAnalysisData<'tcx> {
+    bodies: Vec<BodyItem<'tcx>>,
+    alloc_fns: FxHashSet<LocalDefId>,
+
+    pub call_graph: FxHashMap<LocalDefId, FxHashSet<LocalDefId>>,
+    indirect_calls: HashMap<LocalDefId, HashMap<BasicBlock, usize>>,
+
+    ends: Vec<usize>,
+    globals: HashMap<LocalDefId, usize>,
+    inv_fns: HashMap<usize, LocalDefId>,
+    vars: HashMap<Var, usize>,
+
+    index_prefixes: HashMap<usize, u8>,
+    union_offsets: HashMap<usize, Vec<usize>>,
+    graph: HashMap<LocNode, LocEdges>,
+    var_nodes: HashMap<(LocalDefId, Local), LocNode>,
+}
+
+pub type Solutions = Vec<HybridBitSet<usize>>; // Send not implemented for HybridBitSet
+
+#[derive(Debug)]
+pub struct AnalysisResults {
+    pub ends: Vec<usize>,
+    pub union_offsets: HashMap<usize, Vec<usize>>,
+    pub graph: LocGraph,
+    pub var_nodes: HashMap<(LocalDefId, Local), LocNode>,
+
+    pub solutions: Solutions,
+
+    pub indirect_calls: HashMap<LocalDefId, HashMap<BasicBlock, Vec<LocalDefId>>>,
+    pub call_graph_sccs: FxHashMap<graph::Id, FxHashSet<graph::Id>>,
+    pub scc_elems: FxHashMap<graph::Id, FxHashSet<LocalDefId>>,
+    pub fn_sccs: FxHashMap<LocalDefId, graph::Id>,
+    pub reachables: RefCell<HashMap<usize, HashSet<usize>>>,
+
+    pub writes: HashMap<LocalDefId, HashMap<Location, HybridBitSet<usize>>>,
+    pub bitfield_writes: HashMap<LocalDefId, HashMap<Location, HybridBitSet<usize>>>,
+    pub fn_writes: HashMap<LocalDefId, HybridBitSet<usize>>,
+}
+
+impl AnalysisResults {
+    pub fn call_writes(&self, def_id: LocalDefId) -> HybridBitSet<usize> {
+        self.with_reachables(self.fn_sccs[&def_id].index(), |sccs| {
+            let mut writes = HybridBitSet::new_empty(self.ends.len());
+            for scc in sccs {
+                let idx = graph::Id::new(*scc);
+                for f in &self.scc_elems[&idx] {
+                    writes.union(&self.fn_writes[f]);
+                }
+            }
+            writes
+        })
+    }
+
+    #[inline]
+    fn with_reachables<R, F: FnOnce(&HashSet<usize>) -> R>(&self, scc: usize, f: F) -> R {
+        if let Some(rs) = self.reachables.borrow().get(&scc) {
+            return f(rs);
+        }
+        let mut reachables = HashSet::new();
+        self.reachables_from_scc(scc, &mut reachables);
+        let r = f(&reachables);
+        self.reachables.borrow_mut().insert(scc, reachables.clone());
+        r
+    }
+
+    fn reachables_from_scc(&self, scc: usize, reachables: &mut HashSet<usize>) {
+        if let Some(rs) = self.reachables.borrow().get(&scc) {
+            reachables.extend(rs);
+            return;
+        }
+        let mut this_reachables: HashSet<_> = [scc].into_iter().collect();
+        let idx = graph::Id::new(scc);
+        for succ in &self.call_graph_sccs[&idx] {
+            self.reachables_from_scc(succ.index(), &mut this_reachables);
+        }
+        reachables.extend(this_reachables.iter());
+        self.reachables.borrow_mut().insert(scc, this_reachables);
+    }
+}
+
+pub fn pre_analyze<'a, 'tcx>(
+    tss: &'a TyShapes<'a, 'tcx>,
+    tcx: TyCtxt<'tcx>,
+) -> PreAnalysisData<'tcx> {
+    let alloc_fns = alloc_finder::analyze(tcx);
+
+    let mut bodies = vec![];
+    let mut fn_def_ids = HashSet::new();
+    let mut visitor = FnPtrVisitor::new(tcx);
+    for item_id in tcx.hir_free_items() {
+        let item = tcx.hir_item(item_id);
+        let local_def_id = item.owner_id.def_id;
+        let def_id = local_def_id.to_def_id();
+        match item.kind {
+            ItemKind::Fn { .. } if item.ident.name.as_str() != "main" => {
+                fn_def_ids.insert(local_def_id);
+                let body = tcx.optimized_mir(def_id);
+                visitor.visit_body(body);
+                let body_item = BodyItem {
+                    local_def_id,
+                    body,
+                    is_fn: true,
+                };
+                bodies.push(body_item);
+            }
+            ItemKind::Static(_, _, _) => {
+                let body = tcx.mir_for_ctfe(def_id);
+                visitor.visit_body(body);
+                let body_item = BodyItem {
+                    local_def_id,
+                    body,
+                    is_fn: false,
+                };
+                bodies.push(body_item);
+            }
+            _ => {}
+        }
+    }
+    let mut call_graph: FxHashMap<_, _> = fn_def_ids
+        .iter()
+        .map(|f| (*f, FxHashSet::default()))
+        .collect();
+    let fn_ptrs = visitor.fn_ptrs;
+
+    // local_def_id -> global_index : item with local_def_id has global_index
+    let mut globals = HashMap::new();
+    // global_index -> local_def_id : global_index is a function with local_def_id
+    let mut inv_fns = HashMap::new();
+    // local -> global_index
+    let mut vars = HashMap::new();
+    let mut ends = vec![];
+    let mut alloc_ends: Vec<usize> = vec![];
+    let mut allocs = vec![];
+    let mut graph = HashMap::new();
+    let mut union_offsets = HashMap::new();
+    let mut index_prefixes = HashMap::new();
+    // indirect calls using the var of the global index
+    let mut indirect_calls: HashMap<_, HashMap<_, _>> = HashMap::new();
+    let mut var_nodes = HashMap::new();
+    for item in &bodies {
+        // not c function
+        let fn_ptr = fn_ptrs.contains(&item.local_def_id);
+        let global_index = ends.len();
+        globals.insert(item.local_def_id, global_index);
+
+        if item.is_fn {
+            inv_fns.insert(global_index, item.local_def_id);
+        }
+
+        let mut local_decls = item.body.local_decls.iter_enumerated();
+        let ret = local_decls.next().unwrap();
+        let mut params = vec![];
+        for _ in 0..item.body.arg_count {
+            params.push(local_decls.next().unwrap());
+        }
+        // params -> ret -> other locals
+        let local_decls = params
+            .into_iter()
+            .chain(std::iter::once(ret))
+            .chain(local_decls);
+
+        for (local, local_decl) in local_decls {
+            vars.insert(Var::Local(item.local_def_id, local), ends.len());
+            let ty = tss.tys[&local_decl.ty];
+            let node = add_edges(
+                ty,
+                ends.len(),
+                &mut graph,
+                &mut index_prefixes,
+                &mut union_offsets,
+            );
+            var_nodes.insert((item.local_def_id, local), node);
+            compute_ends(ty, &mut ends);
+
+            // if it is a function return value
+            if fn_ptr && local.index() == 0 {
+                ends[global_index] = ends.len() - 1;
+            }
+
+            // if it is a pointer - modeling heap objects?
+            if let Some(ty) = unwrap_ptr(local_decl.ty) {
+                let mut ends = vec![];
+                let ty = tss.tys[&ty];
+                compute_ends(ty, &mut ends);
+                for (i, end) in ends.into_iter().enumerate() {
+                    if alloc_ends.len() > i {
+                        alloc_ends[i] = alloc_ends[i].max(end);
+                    } else {
+                        alloc_ends.push(end);
+                    }
+                }
+            }
+        }
+
+        for (bb, bbd) in item.body.basic_blocks.iter_enumerated() {
+            let TerminatorKind::Call {
+                func, destination, ..
+            } = &bbd.terminator().kind
+            else {
+                continue;
+            };
+            match func {
+                Operand::Copy(func) | Operand::Move(func) => {
+                    assert!(func.projection.is_empty());
+                    let var = Var::Local(item.local_def_id, func.local);
+                    let index = vars[&var];
+                    indirect_calls
+                        .entry(item.local_def_id)
+                        .or_default()
+                        .insert(bb, index);
+                }
+                _ => {
+                    let def_id = some_or!(operand_to_fn(func), continue);
+                    let local_def_id = some_or!(def_id.as_local(), continue);
+                    let ty = destination.ty(&item.body.local_decls, tcx).ty;
+                    if ty.is_raw_ptr()
+                        && (is_c_fn(def_id, tcx) || alloc_fns.contains(&local_def_id))
+                    {
+                        allocs.push(Var::Alloc(item.local_def_id, bb));
+                    }
+                    if fn_def_ids.contains(&local_def_id) {
+                        call_graph
+                            .get_mut(&item.local_def_id)
+                            .unwrap()
+                            .insert(local_def_id);
+                    }
+                }
+            }
+        }
+    }
+
+    for alloc in allocs {
+        let len = ends.len();
+        vars.insert(alloc, len);
+        for end in &alloc_ends {
+            ends.push(len + *end);
+        }
+    }
+
+    PreAnalysisData {
+        bodies,
+        alloc_fns,
+        call_graph,
+        indirect_calls,
+        ends,
+        globals,
+        inv_fns,
+        vars,
+        index_prefixes,
+        union_offsets,
+        graph,
+        var_nodes,
+    }
+}
+
+pub fn analyze<'a, 'tcx>(
+    pre: &PreAnalysisData<'tcx>,
+    tss: &'a TyShapes<'a, 'tcx>,
+    tcx: TyCtxt<'tcx>,
+) -> Solutions {
+    let mut analyzer = Analyzer {
+        tcx,
+        tss,
+        pre,
+        graph: Graph::new(pre.ends.len()),
+    };
+    for item in &pre.bodies {
+        // println!("{}", compile_util::body_to_str(item.body));
+        for (block, bbd) in item.body.basic_blocks.iter_enumerated() {
+            for stmt in bbd.statements.iter() {
+                let ctx = Context::new(&item.body.local_decls, item.local_def_id);
+                analyzer.transfer_stmt(stmt, ctx);
+            }
+            let terminator = bbd.terminator();
+            let ctx = Context::new(&item.body.local_decls, item.local_def_id);
+            analyzer.transfer_term(terminator, ctx, block);
+        }
+    }
+    analyzer.graph.solve(&pre.ends)
+}
+
+pub fn serialize_solutions(solutions: &Solutions) -> Vec<u8> {
+    let mut arr = vec![];
+    for v in solutions {
+        for mut i in v.iter() {
+            while i > 0 {
+                arr.push((i & 127) as u8);
+                i >>= 7;
+            }
+            arr.push(254);
+        }
+        arr.push(255);
+    }
+    arr.pop();
+    arr
+}
+
+pub fn deserialize_solutions(arr: &[u8]) -> Solutions {
+    let size = arr.iter().filter(|n| **n == 255).count() + 1;
+    let mut solutions: Solutions = vec![HybridBitSet::new_empty(size)];
+    let mut s = &mut solutions[0];
+    let mut i = 0;
+    let mut len = 0;
+    for n in arr {
+        match *n {
+            255 => {
+                solutions.push(HybridBitSet::new_empty(size));
+                s = solutions.last_mut().unwrap();
+            }
+            254 => {
+                s.insert(i);
+                i = 0;
+                len = 0;
+            }
+            n => {
+                i |= (n as usize) << len;
+                len += 7;
+            }
+        }
+    }
+    solutions
+}
+
+pub fn post_analyze<'a, 'tcx>(
+    mut pre: PreAnalysisData<'tcx>,
+    solutions: Solutions,
+    tss: &'a TyShapes<'a, 'tcx>,
+    tcx: TyCtxt<'tcx>,
+) -> AnalysisResults {
+    for (index, sols) in solutions.iter().enumerate() {
+        let node = LocNode::new(0, index);
+        let mut succs = vec![];
+        for succ in sols.iter() {
+            let max = pre.index_prefixes.get(&succ).cloned().unwrap_or(0);
+            succs.extend((0..=max).map(|p| LocNode::new(p, succ)));
+        }
+        pre.graph.insert(node, LocEdges::Deref(succs));
+    }
+    let mut address_taken_indices = HybridBitSet::new_empty(pre.ends.len());
+    for indices in &solutions {
+        address_taken_indices.union(indices);
+    }
+    for (i, _) in pre.ends.iter().enumerate() {
+        if address_taken_indices.contains(i) {
+            for j in (i + 1)..=pre.ends[i] {
+                address_taken_indices.insert(j);
+            }
+        }
+    }
+
+    let analyzer = Analyzer {
+        tcx,
+        pre: &pre,
+        tss,
+        graph: Graph::new(pre.ends.len()),
+    };
+    let mut writes: HashMap<_, HashMap<_, _>> = HashMap::new();
+    let mut bitfield_writes: HashMap<_, HashMap<_, _>> = HashMap::new();
+    for item in &pre.bodies {
+        let writes = writes.entry(item.local_def_id).or_default();
+        let bitfield_writes = bitfield_writes.entry(item.local_def_id).or_default();
+        let ctx = Context::new(&item.body.local_decls, item.local_def_id);
+        for (block, bbd) in item.body.basic_blocks.iter_enumerated() {
+            for (statement_index, stmt) in bbd.statements.iter().enumerate() {
+                let StatementKind::Assign(box (l, _)) = stmt.kind else {
+                    continue;
+                };
+                let location = Location {
+                    block,
+                    statement_index,
+                };
+                compute_writes(l, location, &pre.ends, &solutions, ctx, &analyzer, writes);
+            }
+            if let TerminatorKind::Call {
+                func,
+                args,
+                destination,
+                ..
+            } = &bbd.terminator().kind
+            {
+                let location = Location {
+                    block,
+                    statement_index: bbd.statements.len(),
+                };
+                compute_writes(
+                    *destination,
+                    location,
+                    &pre.ends,
+                    &solutions,
+                    ctx,
+                    &analyzer,
+                    writes,
+                );
+                compute_bitfield_writes(
+                    func,
+                    args,
+                    location,
+                    tss,
+                    tcx,
+                    &pre.ends,
+                    &solutions,
+                    ctx,
+                    &analyzer,
+                    bitfield_writes,
+                );
+            }
+        }
+    }
+    // only keep poinatble writes
+    for writes in writes.values_mut() {
+        for writes in writes.values_mut() {
+            writes.intersect(&address_taken_indices);
+        }
+    }
+    let fn_writes: HashMap<_, _> = writes
+        .iter()
+        .map(|(f, writes)| {
+            let mut ws = HybridBitSet::new_empty(pre.ends.len());
+            for w in writes.values() {
+                ws.union(w);
+            }
+            (*f, ws)
+        })
+        .collect();
+
+    let indirect_calls: HashMap<_, HashMap<_, Vec<_>>> = pre
+        .indirect_calls
+        .into_iter()
+        .map(|(def_id, calls)| {
+            let calls = calls
+                .into_iter()
+                .map(|(bb, index)| {
+                    let callees = solutions[index]
+                        .iter()
+                        .filter_map(|index| pre.inv_fns.get(&index).copied())
+                        .collect();
+                    (bb, callees)
+                })
+                .collect();
+            (def_id, calls)
+        })
+        .collect();
+    for (caller, calls) in &indirect_calls {
+        let callees = pre.call_graph.get_mut(caller).unwrap();
+        callees.extend(calls.values().flatten());
+    }
+    let (call_graph_sccs, scc_elems) = graph::compute_sccs(&pre.call_graph);
+    let fn_sccs = scc_elems
+        .iter()
+        .flat_map(|(id, fs)| fs.iter().map(|f| (*f, *id)))
+        .collect();
+
+    AnalysisResults {
+        ends: pre.ends,
+        union_offsets: pre.union_offsets,
+        graph: pre.graph,
+        var_nodes: pre.var_nodes,
+        solutions,
+        indirect_calls,
+        call_graph_sccs,
+        scc_elems,
+        fn_sccs,
+        reachables: RefCell::new(HashMap::new()),
+        writes,
+        bitfield_writes,
+        fn_writes,
+    }
+}
+
+fn compute_ends(ty: &TyShape<'_>, ends: &mut Vec<usize>) {
+    match ty {
+        TyShape::Primitive => ends.push(ends.len()),
+        TyShape::Array(t, _) => compute_ends(t, ends),
+        TyShape::Struct(len, ts, _) => {
+            let end = ends.len();
+            for (_, t) in ts {
+                compute_ends(t, ends);
+            }
+            ends[end] = end + *len - 1;
+        }
+    }
+}
+
+#[inline]
+fn compute_writes<'tcx>(
+    l: Place<'tcx>,
+    location: Location,
+    ends: &[usize],
+    solutions: &[HybridBitSet<usize>],
+    ctx: Context<'_, 'tcx>,
+    analyzer: &Analyzer<'_, '_, 'tcx>,
+    writes: &mut HashMap<Location, HybridBitSet<usize>>,
+) {
+    let writes = writes
+        .entry(location)
+        .or_insert(HybridBitSet::new_empty(ends.len()));
+    let ty = l.ty(ctx.locals, analyzer.tcx).ty;
+    let len = analyzer.tss.tys[&ty].len();
+    let l = analyzer.prefixed_loc(l, ctx);
+    if l.deref {
+        for loc in solutions[l.var.root].iter() {
+            let loc = loc + l.var.proj;
+            let end = *some_or!(ends.get(loc), continue);
+            for i in 0..len {
+                if loc + i > end {
+                    break;
+                }
+                writes.insert(loc + i);
+            }
+        }
+    } else {
+        let loc = l.var.root + l.var.proj;
+        for i in 0..len {
+            writes.insert(loc + i);
+        }
+    }
+}
+
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn compute_bitfield_writes<'tcx>(
+    func: &Operand<'tcx>,
+    args: &[Spanned<Operand<'tcx>>],
+    location: Location,
+    tss: &TyShapes<'_, 'tcx>,
+    tcx: TyCtxt<'tcx>,
+    ends: &[usize],
+    solutions: &[HybridBitSet<usize>],
+    ctx: Context<'_, 'tcx>,
+    analyzer: &Analyzer<'_, '_, 'tcx>,
+    writes: &mut HashMap<Location, HybridBitSet<usize>>,
+) {
+    if args.len() != 2 {
+        return;
+    }
+    let Operand::Constant(box constant) = func else {
+        return;
+    };
+    let Const::Val(_, ty) = constant.const_ else {
+        unreachable!()
+    };
+    let TyKind::FnDef(def_id, _) = ty.kind() else {
+        unreachable!()
+    };
+    let local_def_id = some_or!(def_id.as_local(), return);
+    let (local_def_id, method) = some_or!(receiver_and_method(local_def_id, tcx), return);
+    let field = method.strip_prefix("set_").unwrap();
+    let TyKind::Ref(_, ty, _) = args[0].node.ty(ctx.locals, tcx).kind() else {
+        unreachable!()
+    };
+    let TyShape::Struct(_, fs, _) = tss.tys[ty] else {
+        unreachable!()
+    };
+    let idx = tss.bitfields[&local_def_id].name_to_idx[field];
+    let offset = fs[idx.as_usize()].0;
+    let lhs = args[0].node.place().unwrap();
+    assert!(lhs.projection.is_empty());
+    let l = analyzer.prefixed_loc(lhs, ctx);
+    let writes = writes
+        .entry(location)
+        .or_insert(HybridBitSet::new_empty(ends.len()));
+    for loc in solutions[l.var.root].iter() {
+        let loc = loc + offset;
+        let end = ends[loc];
+        if loc <= end {
+            writes.insert(loc);
+        }
+    }
+}
+
+pub fn receiver_and_method(
+    local_def_id: LocalDefId,
+    tcx: TyCtxt<'_>,
+) -> Option<(LocalDefId, String)> {
+    let hir = tcx.hir();
+    let impl_def_id = tcx.impl_of_method(local_def_id.to_def_id())?;
+    let impl_item = hir.expect_impl_item(local_def_id);
+    let method = impl_item.ident.name.to_ident_string();
+    let item = hir.expect_item(impl_def_id.expect_local());
+    let ItemKind::Impl(imp) = item.kind else {
+        unreachable!()
+    };
+    let HirTyKind::Path(QPath::Resolved(_, path)) = imp.self_ty.kind else {
+        unreachable!()
+    };
+    let Res::Def(_, struct_def_id) = path.res else {
+        unreachable!()
+    };
+    let local_def_id = struct_def_id.expect_local();
+    Some((local_def_id, method))
+}
+
+fn add_edges(
+    ty: &TyShape<'_>,
+    index: usize, // global index
+    graph: &mut LocGraph,
+    index_prefixes: &mut HashMap<usize, u8>,
+    union_offsets: &mut HashMap<usize, Vec<usize>>,
+) -> LocNode {
+    let node = match ty {
+        TyShape::Primitive => return LocNode::new(0, index),
+        TyShape::Array(t, _) => {
+            let succ = add_edges(t, index, graph, index_prefixes, union_offsets);
+            let node = succ.parent();
+            graph.insert(node, LocEdges::Index(succ));
+            node
+        }
+        TyShape::Struct(len, ts, is_union) => {
+            let succs: IndexVec<FieldIdx, _> = ts
+                .iter()
+                .map(|(offset, t)| {
+                    add_edges(t, index + offset, graph, index_prefixes, union_offsets)
+                })
+                .collect();
+            let node = succs[FieldIdx::from_u32(0)].parent();
+            graph.insert(node, LocEdges::Fields(succs));
+            if *is_union {
+                let mut offsets: Vec<usize> = ts.iter().map(|(offset, _)| *offset).collect();
+                offsets.push(*len);
+                union_offsets.insert(index, offsets);
+            }
+            node
+        }
+    };
+    index_prefixes.insert(index, node.prefix);
+    node
+}
+
+pub type LocGraph = HashMap<LocNode, LocEdges>;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LocNode {
+    pub prefix: u8,
+    pub index: usize,
+}
+
+impl std::fmt::Debug for LocNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.index)?;
+        if self.prefix != 0 {
+            write!(f, ":{}", self.prefix)?;
+        }
+        Ok(())
+    }
+}
+
+impl LocNode {
+    fn new(prefix: u8, index: usize) -> Self {
+        Self { prefix, index }
+    }
+
+    fn parent(self) -> Self {
+        Self {
+            prefix: self.prefix + 1,
+            index: self.index,
+        }
+    }
+}
+
+pub enum LocEdges {
+    Fields(IndexVec<FieldIdx, LocNode>),
+    Index(LocNode),
+    Deref(Vec<LocNode>),
+}
+
+impl std::fmt::Debug for LocEdges {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LocEdges::Fields(succs) => {
+                write!(f, "[")?;
+                for (i, succ) in succs.iter().enumerate() {
+                    if i != 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}: {:?}", i, succ)?;
+                }
+                write!(f, "]")
+            }
+            LocEdges::Index(succ) => write!(f, "[_: {:?}]", succ),
+            LocEdges::Deref(succs) => {
+                write!(f, "[")?;
+                for (i, field) in succs.iter().enumerate() {
+                    if i != 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "*: {:?}", field)?;
+                }
+                write!(f, "]")
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Context<'a, 'tcx> {
+    locals: &'a IndexVec<Local, LocalDecl<'tcx>>,
+    owner: LocalDefId,
+}
+
+impl<'a, 'tcx> Context<'a, 'tcx> {
+    #[inline]
+    fn new(locals: &'a IndexVec<Local, LocalDecl<'tcx>>, owner: LocalDefId) -> Self {
+        Self { locals, owner }
+    }
+}
+
+struct Analyzer<'a, 'b, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    pre: &'b PreAnalysisData<'tcx>,
+    tss: &'a TyShapes<'a, 'tcx>,
+    graph: Graph,
+}
+
+impl<'tcx> Analyzer<'_, '_, 'tcx> {
+    fn transfer_stmt(&mut self, stmt: &Statement<'tcx>, ctx: Context<'_, 'tcx>) {
+        let StatementKind::Assign(box (l, r)) = &stmt.kind else {
+            return;
+        };
+        let ty = l.ty(ctx.locals, self.tcx).ty;
+        let l = self.prefixed_loc(*l, ctx);
+        match r {
+            Rvalue::Use(r) => {
+                if let Some(r) = self.transfer_op(r, ctx) {
+                    self.transfer_assign(l, r, ty);
+                }
+            }
+            Rvalue::Repeat(r, _) => {
+                if let Some(r) = self.transfer_op(r, ctx) {
+                    let TyKind::Array(ty, _) = ty.kind() else {
+                        unreachable!()
+                    };
+                    self.transfer_assign(l, r, *ty);
+                }
+            }
+            Rvalue::Ref(_, _, r) => {
+                let r = self.prefixed_loc(*r, ctx).with_ref(true);
+                self.transfer_assign(l, r, ty);
+            }
+            Rvalue::ThreadLocalRef(r) => {
+                if let Some(r) = self.static_ref(*r) {
+                    self.transfer_assign(l, r, ty);
+                }
+            }
+            Rvalue::RawPtr(_, r) => {
+                assert!(r.is_indirect_first_projection());
+                let r = self.prefixed_loc(*r, ctx).with_deref(false);
+                self.transfer_assign(l, r, ty);
+            }
+            Rvalue::Len(_) => {}
+            Rvalue::Cast(_, r, _) => {
+                if let Some(r) = self.transfer_op(r, ctx) {
+                    self.transfer_assign(l, r, ty);
+                }
+            }
+            Rvalue::BinaryOp(op, box (r1, r2)) => {
+                if !matches!(
+                    op,
+                    BinOp::Eq | BinOp::Lt | BinOp::Le | BinOp::Ne | BinOp::Ge | BinOp::Gt
+                ) {
+                    if let Some(r) = self.transfer_op(r1, ctx) {
+                        if !r.deref {
+                            self.transfer_assign(l, r, ty);
+                        }
+                    }
+                    if let Some(r) = self.transfer_op(r2, ctx) {
+                        self.transfer_assign(l, r, ty);
+                    }
+                }
+            }
+            Rvalue::NullaryOp(_, _) => unreachable!(),
+            Rvalue::UnaryOp(op, r) => {
+                if matches!(op, UnOp::Neg) {
+                    if let Some(r) = self.transfer_op(r, ctx) {
+                        self.transfer_assign(l, r, ty);
+                    }
+                }
+            }
+            Rvalue::Discriminant(_) => {}
+            Rvalue::Aggregate(box kind, fs) => match kind {
+                AggregateKind::Array(ty) => {
+                    for f in fs.iter() {
+                        if let Some(r) = self.transfer_op(f, ctx) {
+                            self.transfer_assign(l, r, *ty);
+                        }
+                    }
+                }
+                AggregateKind::Adt(_, v_idx, _, _, idx) => {
+                    let TyShape::Struct(_, ts, _) = self.tss.tys[&ty] else {
+                        unreachable!()
+                    };
+                    let TyKind::Adt(adt_def, generic_args) = ty.kind() else {
+                        unreachable!()
+                    };
+                    let variant = adt_def.variant(*v_idx);
+                    for ((i, d), f) in variant.fields.iter_enumerated().zip(fs) {
+                        if let Some(r) = self.transfer_op(f, ctx) {
+                            let i = if let Some(idx) = idx { *idx } else { i };
+                            let proj = ts[i.index()].0;
+                            let ty = d.ty(self.tcx, generic_args);
+                            self.transfer_assign(l.add(proj), r, ty);
+                        }
+                    }
+                }
+                _ => unreachable!(),
+            },
+            Rvalue::ShallowInitBox(_, _) => unreachable!(),
+            Rvalue::CopyForDeref(r) => {
+                let r = self.prefixed_loc(*r, ctx);
+                self.transfer_assign(l, r, ty);
+            }
+            Rvalue::WrapUnsafeBinder(_, _) => unreachable!(),
+        }
+    }
+
+    fn transfer_assign(&mut self, l: PrefixedLoc, r: PrefixedLoc, ty: Ty<'tcx>) {
+        assert!(!l.r#ref);
+        let len = self.tss.tys[&ty].len();
+        for i in 0..len {
+            let l = l.add(i);
+            let r = r.add(i);
+            match (l.deref, r.r#ref, r.deref) {
+                (true, true, _) => unreachable!(),
+                (true, false, true) => unreachable!(),
+                (true, false, false) => self.graph.add_deref_eq(l.var.root, l.var.proj, r.index()), /* *l = r : *l >= r */
+                (false, true, true) => self.graph.add_edge(l.index(), r.var.root, r.var.proj), /* l = &*r ? */
+                (false, true, false) => self.graph.add_solution(l.index(), r.index()), /* l = &r : l >= { r } */
+                (false, false, true) => self.graph.add_eq_deref(l.index(), r.var.root, r.var.proj), /* l = *r : l >= *r // edge from sol(r) to l */
+                (false, false, false) => self.graph.add_edge(l.index(), r.index(), 0), /* l = r : l >= r */
+            }
+        }
+    }
+
+    fn transfer_op(&mut self, op: &Operand<'tcx>, ctx: Context<'_, 'tcx>) -> Option<PrefixedLoc> {
+        match op {
+            Operand::Copy(place) | Operand::Move(place) => Some(self.prefixed_loc(*place, ctx)),
+            Operand::Constant(box constant) => match constant.const_ {
+                Const::Ty(_, _) => unreachable!(),
+                Const::Unevaluated(_, _) => None,
+                Const::Val(value, ty) => match value {
+                    ConstValue::Scalar(scalar) => match scalar {
+                        Scalar::Int(_) => None,
+                        Scalar::Ptr(ptr, _) => {
+                            match self.tcx.global_alloc(ptr.provenance.alloc_id()) {
+                                GlobalAlloc::Static(def_id) => self.static_ref(def_id),
+                                GlobalAlloc::Memory(_) => None,
+                                _ => unreachable!(),
+                            }
+                        }
+                    },
+                    ConstValue::ZeroSized => {
+                        let TyKind::FnDef(def_id, _) = ty.kind() else {
+                            unreachable!()
+                        };
+                        let var =
+                            Loc::new_root(self.pre.globals.get(&def_id.as_local()?).copied()?);
+                        Some(PrefixedLoc::new_ref(var))
+                    }
+                    ConstValue::Slice { .. } => None,
+                    _ => unreachable!(),
+                },
+            },
+        }
+    }
+
+    fn transfer_term(
+        &mut self,
+        term: &Terminator<'tcx>,
+        ctx: Context<'_, 'tcx>,
+        block: BasicBlock,
+    ) {
+        let TerminatorKind::Call {
+            func,
+            args,
+            destination,
+            ..
+        } = &term.kind
+        else {
+            return;
+        };
+        assert!(destination.projection.is_empty());
+
+        let arg_locs: Vec<_> = args
+            .iter()
+            .map(|arg| self.transfer_op(&arg.node, ctx))
+            .collect();
+        let output = destination.ty(ctx.locals, self.tcx).ty;
+        let dst = self.prefixed_loc(*destination, ctx);
+
+        match func {
+            Operand::Copy(func) | Operand::Move(func) => {
+                assert!(func.projection.is_empty());
+                let mut func = self.prefixed_loc(*func, ctx).with_deref(true);
+                for (arg, arg_loc) in args.iter().zip(arg_locs) {
+                    let ty = arg.node.ty(ctx.locals, self.tcx);
+                    if let Some(arg) = arg_loc {
+                        self.transfer_assign(func, arg, ty);
+                    }
+                    func = func.add(self.tss.tys[&ty].len());
+                }
+                self.transfer_assign(dst, func, output);
+            }
+            Operand::Constant(box constant) => {
+                let Const::Val(value, ty) = constant.const_ else {
+                    unreachable!()
+                };
+                assert!(matches!(value, ConstValue::ZeroSized));
+                let TyKind::FnDef(def_id, _) = ty.kind() else {
+                    unreachable!()
+                };
+                let name: Vec<_> = self
+                    .tcx
+                    .def_path(*def_id)
+                    .data
+                    .into_iter()
+                    .map(|data| data.to_string())
+                    .collect();
+                let is_extern = name.iter().any(|s| s.starts_with("{extern#"));
+                let seg = |i: usize| name.get(i).map(|s| s.as_str()).unwrap_or_default();
+                let name = (seg(0), seg(1), seg(2), seg(3));
+                if let Some(local_def_id) = def_id.as_local() {
+                    if let Some(impl_def_id) = self.tcx.impl_of_method(*def_id) {
+                        let span = self.tcx.span_of_impl(impl_def_id).unwrap();
+                        let code = self.tcx.sess.source_map().span_to_snippet(span).unwrap();
+                        assert_eq!(code, "BitfieldStruct");
+                    } else if is_extern {
+                        if output.is_raw_ptr() {
+                            let var = Var::Alloc(ctx.owner, block);
+                            let loc = Loc::new_root(self.pre.vars[&var]);
+                            self.transfer_assign(dst, PrefixedLoc::new_ref(loc), output);
+                        }
+                    } else if self.pre.alloc_fns.contains(&local_def_id) {
+                        let var = Var::Alloc(ctx.owner, block);
+                        let loc = Loc::new_root(self.pre.vars[&var]);
+                        self.transfer_assign(dst, PrefixedLoc::new_ref(loc), output);
+                    } else {
+                        let mut index = self.pre.globals[&local_def_id];
+                        for (arg, arg_loc) in args.iter().zip(arg_locs) {
+                            let ty = arg.node.ty(ctx.locals, self.tcx);
+                            if let Some(arg) = arg_loc {
+                                let loc = Loc::new_root(index);
+                                self.transfer_assign(PrefixedLoc::new(loc), arg, ty);
+                            }
+                            index += self.tss.tys[&ty].len();
+                        }
+                        let loc = Loc::new_root(index);
+                        self.transfer_assign(dst, PrefixedLoc::new(loc), output);
+                    }
+                } else {
+                    match name {
+                        ("option" | "result", _, "unwrap", _)
+                        | ("slice", _, "as_ptr" | "as_mut_ptr", _)
+                        | ("ptr", _, _, "offset") => {
+                            if let Some(arg) = &arg_locs[0] {
+                                self.transfer_assign(dst, *arg, output);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    fn static_ref(&self, def_id: DefId) -> Option<PrefixedLoc> {
+        let var = Var::Local(def_id.as_local()?, Local::new(0));
+        let loc = Loc::new_root(self.pre.vars.get(&var).copied()?);
+        Some(PrefixedLoc::new_ref(loc))
+    }
+
+    fn prefixed_loc(&self, place: Place<'tcx>, ctx: Context<'_, 'tcx>) -> PrefixedLoc {
+        let mut index = 0;
+        let mut ty = ctx.locals[place.local].ty;
+        let deref = place.is_indirect_first_projection();
+        if deref {
+            ty = unwrap_ptr(ty).unwrap();
+        }
+        let mut ty = self.tss.tys[&ty];
+        for proj in place.projection {
+            match proj {
+                PlaceElem::Deref => {}
+                PlaceElem::Index(_) => {
+                    let TyShape::Array(t, _) = ty else {
+                        unreachable!()
+                    };
+                    ty = t;
+                }
+                PlaceElem::Field(f, _) => {
+                    let TyShape::Struct(_, fs, _) = ty else {
+                        unreachable!()
+                    };
+                    let (i, nested_ty) = fs[f.index()];
+                    index += i;
+                    ty = nested_ty;
+                }
+                _ => unreachable!(),
+            }
+        }
+        let var = Var::Local(ctx.owner, place.local);
+        let loc = Loc::new(self.pre.vars[&var], index);
+        PrefixedLoc::new(loc).with_deref(place.is_indirect_first_projection())
+    }
+}
+
+type WeightedGraph = HashMap<usize, HashMap<usize, HashSet<usize>>>;
+
+struct Graph {
+    solutions: Solutions,
+    zero_weight_edges: Vec<HybridBitSet<usize>>,
+    pos_weight_edges: WeightedGraph,
+    deref_eqs: WeightedGraph,
+    eq_derefs: WeightedGraph,
+}
+
+impl std::fmt::Debug for Graph {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "solutions: ")?;
+        for (i, sol) in self.solutions.iter().enumerate() {
+            write!(f, "{}: {:?}, ", i, sol.iter().collect::<Vec<_>>())?;
+        }
+        write!(f, "\nzero_weight_edges: ")?;
+        for (i, sol) in self.zero_weight_edges.iter().enumerate() {
+            write!(f, "{}: {:?}, ", i, sol.iter().collect::<Vec<_>>())?;
+        }
+        write!(f, "\npos_weight_edges: {:?}", self.pos_weight_edges)?;
+        write!(f, "\nderef_eqs: {:?}", self.deref_eqs)?;
+        write!(f, "\neq_derefs: {:?}", self.eq_derefs)
+    }
+}
+
+impl Graph {
+    fn new(size: usize) -> Self {
+        Self {
+            solutions: vec![HybridBitSet::new_empty(size); size],
+            zero_weight_edges: vec![HybridBitSet::new_empty(size); size],
+            pos_weight_edges: HashMap::new(),
+            deref_eqs: HashMap::new(),
+            eq_derefs: HashMap::new(),
+        }
+    }
+
+    fn add_solution(&mut self, v: usize, sol: usize) {
+        self.solutions[v.index()].insert(sol);
+    }
+
+    fn add_edge(&mut self, l: usize, r: usize, weight: usize) {
+        if weight == 0 {
+            self.zero_weight_edges[r].insert(l);
+        } else {
+            self.pos_weight_edges
+                .entry(r)
+                .or_default()
+                .entry(l)
+                .or_default()
+                .insert(weight);
+        }
+    }
+
+    fn add_deref_eq(&mut self, v: usize, proj: usize, i: usize) {
+        self.deref_eqs
+            .entry(v)
+            .or_default()
+            .entry(i)
+            .or_default()
+            .insert(proj);
+    }
+
+    fn add_eq_deref(&mut self, i: usize, v: usize, proj: usize) {
+        self.eq_derefs
+            .entry(v)
+            .or_default()
+            .entry(i)
+            .or_default()
+            .insert(proj);
+    }
+
+    fn solve(self, ends: &[usize]) -> Solutions {
+        let Self {
+            mut solutions,
+            mut zero_weight_edges,
+            mut pos_weight_edges,
+            mut deref_eqs,
+            mut eq_derefs,
+        } = self;
+        let len = solutions.len();
+
+        let mut deltas = solutions.clone();
+        let mut id_to_rep = Vec::from_iter(0..len);
+
+        while deltas.iter().any(|s| !s.is_empty()) {
+            let sccs: Sccs<_, usize> = Sccs::new(&VecBitSet(&zero_weight_edges));
+
+            let mut components = vec![HybridBitSet::new_empty(len); sccs.num_sccs()];
+            for i in 0..len {
+                let scc = sccs.scc(i);
+                components[scc.index()].insert(i);
+            }
+
+            let mut scc_to_rep = vec![];
+            let mut cycles = vec![];
+            let mut new_id_to_rep = HashMap::new();
+            for component in components.iter() {
+                let rep = component.iter().next().unwrap();
+                scc_to_rep.push(rep);
+                if contains_multiple(component) {
+                    cycles.push((rep, component));
+                    for id in component.iter() {
+                        if id != rep {
+                            new_id_to_rep.insert(id, rep);
+                        }
+                    }
+                }
+            }
+
+            let mut po = vec![];
+            for scc in sccs.all_sccs() {
+                po.push(scc_to_rep[scc]);
+            }
+
+            if sccs.num_sccs() != len {
+                // update id_to_rep
+                for rep in &mut id_to_rep {
+                    if let Some(new_rep) = new_id_to_rep.get(rep) {
+                        *rep = *new_rep;
+                    }
+                }
+
+                // update deltas
+                for (rep, ids) in &cycles {
+                    for id in ids.iter() {
+                        if *rep != id {
+                            let set =
+                                std::mem::replace(&mut deltas[id], HybridBitSet::new_empty(len));
+                            deltas[*rep].union(&set);
+                        }
+                    }
+                }
+
+                // update solutions
+                for (rep, ids) in &cycles {
+                    let mut intersection = HybridBitSet::new_empty(len);
+                    intersection.insert_all();
+                    for id in ids.iter() {
+                        intersection.intersect(&solutions[id]);
+                        if *rep != id {
+                            let set =
+                                std::mem::replace(&mut solutions[id], HybridBitSet::new_empty(len));
+                            solutions[*rep].union(&set);
+                        }
+                    }
+                    let mut union = solutions[*rep].clone();
+                    union.subtract(&intersection);
+                    deltas[*rep].union(&union);
+                }
+
+                // update zero_weight_edges
+                zero_weight_edges = vec![HybridBitSet::new_empty(len); len];
+                for (scc, rep) in scc_to_rep.iter().enumerate() {
+                    let succs = &mut zero_weight_edges[*rep];
+                    for succ in sccs.successors(scc) {
+                        succs.insert(scc_to_rep[*succ]);
+                    }
+                }
+
+                // update pos_weight_edges
+                update_weighted_graph(&mut pos_weight_edges, &cycles);
+                // update deref_eqs
+                update_weighted_graph(&mut deref_eqs, &cycles);
+                // update eq_derefs
+                update_weighted_graph(&mut eq_derefs, &cycles);
+            }
+
+            for v in po.into_iter().rev() {
+                if deltas[v].is_empty() {
+                    continue;
+                }
+                let delta = std::mem::replace(&mut deltas[v], HybridBitSet::new_empty(len));
+
+                propagate_deref(
+                    v,
+                    &deref_eqs,
+                    &delta,
+                    ends,
+                    &id_to_rep,
+                    &mut zero_weight_edges,
+                    &mut solutions,
+                    &mut deltas,
+                    true,
+                );
+                propagate_deref(
+                    v,
+                    &eq_derefs,
+                    &delta,
+                    ends,
+                    &id_to_rep,
+                    &mut zero_weight_edges,
+                    &mut solutions,
+                    &mut deltas,
+                    false,
+                );
+
+                for l in zero_weight_edges[v].iter() {
+                    if l == v {
+                        continue;
+                    }
+                    for f in delta.iter() {
+                        if solutions[l].insert(f) {
+                            deltas[l].insert(f);
+                        }
+                    }
+                }
+
+                if let Some(pos_weight_edges) = pos_weight_edges.get(&v) {
+                    for (l, projs) in pos_weight_edges {
+                        for proj in projs {
+                            for i in delta.iter() {
+                                let f = i + proj;
+                                if f > ends[i] {
+                                    continue;
+                                }
+                                if !solutions[*l].insert(f) {
+                                    continue;
+                                }
+                                deltas[*l].insert(f);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        for (id, rep) in id_to_rep.iter().enumerate() {
+            if id != *rep {
+                solutions[id] = solutions[*rep].clone();
+            }
+        }
+
+        solutions
+    }
+}
+
+fn update_weighted_graph(graph: &mut WeightedGraph, cycles: &[(usize, &HybridBitSet<usize>)]) {
+    for (rep, ids) in cycles {
+        let mut rep_edges = graph.remove(rep).unwrap_or_default();
+        for id in ids.iter() {
+            if let Some(edges) = graph.remove(&id) {
+                for (l, weights) in edges {
+                    match rep_edges.entry(l) {
+                        Entry::Occupied(mut entry) => {
+                            entry.get_mut().extend(weights);
+                        }
+                        Entry::Vacant(entry) => {
+                            entry.insert(weights);
+                        }
+                    }
+                }
+            }
+        }
+        if !rep_edges.is_empty() {
+            graph.insert(*rep, rep_edges);
+        }
+    }
+    for edges in graph.values_mut() {
+        for (rep, ids) in cycles {
+            let mut rep_weights = edges.remove(rep).unwrap_or_default();
+            for id in ids.iter() {
+                if let Some(weights) = edges.remove(&id) {
+                    rep_weights.extend(weights);
+                }
+            }
+            if !rep_weights.is_empty() {
+                edges.insert(*rep, rep_weights);
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+#[inline]
+fn propagate_deref(
+    v: usize,
+    derefs: &WeightedGraph,
+    delta: &HybridBitSet<usize>,
+    ends: &[usize],
+    id_to_rep: &[usize],
+    zero_weight_edges: &mut [HybridBitSet<usize>],
+    solutions: &mut [HybridBitSet<usize>],
+    deltas: &mut [HybridBitSet<usize>],
+    deref_eq: bool,
+) {
+    let derefs = some_or!(derefs.get(&v), return);
+    for (w, projs) in derefs {
+        for proj in projs {
+            for i in delta.iter() {
+                let f = i + proj;
+                if f > ends[i] {
+                    continue;
+                }
+                let f = id_to_rep[f];
+                let (l, r) = if deref_eq { (f, *w) } else { (*w, f) };
+                if !zero_weight_edges[r].insert(l) {
+                    continue;
+                }
+                let mut diff = solutions[r].clone();
+                diff.subtract(&solutions[l]);
+                if !diff.is_empty() {
+                    solutions[l].union(&diff);
+                    deltas[l].union(&diff);
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum Var {
+    Local(LocalDefId, Local),
+    Alloc(LocalDefId, BasicBlock),
+}
+
+impl std::fmt::Debug for Var {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Var::Local(def_id, local) => write!(f, "{:?}::{:?}", def_id, local),
+            Var::Alloc(def_id, bb) => write!(f, "{:?}::{:?}", def_id, bb),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct Loc {
+    root: usize,
+    proj: usize,
+}
+
+impl std::fmt::Debug for Loc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.root)?;
+        if self.proj != 0 {
+            write!(f, "+{}", self.proj)?;
+        }
+        Ok(())
+    }
+}
+
+impl Loc {
+    #[inline]
+    fn new(root: usize, proj: usize) -> Self {
+        Self { root, proj }
+    }
+
+    #[inline]
+    fn new_root(root: usize) -> Self {
+        Self { root, proj: 0 }
+    }
+
+    #[inline]
+    fn add(self, proj: usize) -> Self {
+        Self {
+            proj: self.proj + proj,
+            ..self
+        }
+    }
+
+    #[inline]
+    fn index(self) -> usize {
+        self.root + self.proj
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct PrefixedLoc {
+    deref: bool,
+    r#ref: bool,
+    var: Loc,
+}
+
+impl PrefixedLoc {
+    #[inline]
+    fn new(var: Loc) -> Self {
+        Self {
+            deref: false,
+            r#ref: false,
+            var,
+        }
+    }
+
+    #[inline]
+    fn new_ref(var: Loc) -> Self {
+        Self {
+            deref: false,
+            r#ref: true,
+            var,
+        }
+    }
+
+    #[inline]
+    fn with_deref(self, deref: bool) -> Self {
+        Self { deref, ..self }
+    }
+
+    #[inline]
+    fn with_ref(self, r#ref: bool) -> Self {
+        Self { r#ref, ..self }
+    }
+
+    #[inline]
+    fn add(self, proj: usize) -> Self {
+        Self {
+            var: self.var.add(proj),
+            ..self
+        }
+    }
+
+    #[inline]
+    fn index(self) -> usize {
+        self.var.index()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LocProjection {
+    Field(usize),
+    Index,
+    Deref,
+}
+
+#[inline]
+pub fn unwrap_ptr(ty: Ty<'_>) -> Option<Ty<'_>> {
+    match ty.kind() {
+        TyKind::Ref(_, ty, _) | TyKind::RawPtr(ty, ..) => Some(*ty),
+        _ => None,
+    }
+}
+
+#[inline]
+fn operand_to_fn(operand: &Operand<'_>) -> Option<DefId> {
+    let constant = operand.constant()?;
+    let Const::Val(_, ty) = constant.const_ else {
+        return None;
+    };
+    let TyKind::FnDef(def_id, _) = ty.kind() else {
+        return None;
+    };
+    Some(*def_id)
+}
+
+#[inline]
+fn is_c_fn(def_id: DefId, tcx: TyCtxt<'_>) -> bool {
+    for data in tcx.def_path(def_id).data {
+        if data.to_string().starts_with("{extern#") {
+            return true;
+        }
+    }
+    false
+}
+
+#[inline]
+fn contains_multiple<T: Idx>(set: &HybridBitSet<T>) -> bool {
+    let mut iter = set.iter();
+    iter.next().is_some() && iter.next().is_some()
+}
+
+struct FnPtrVisitor<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    fn_ptrs: HashSet<LocalDefId>,
+}
+
+impl<'tcx> FnPtrVisitor<'tcx> {
+    #[inline]
+    fn new(tcx: TyCtxt<'tcx>) -> Self {
+        Self {
+            tcx,
+            fn_ptrs: HashSet::new(),
+        }
+    }
+
+    fn get_function(&self, operand: &Operand<'tcx>) -> Option<LocalDefId> {
+        let constant = operand.constant()?;
+        let Const::Val(_, ty) = constant.const_ else {
+            return None;
+        };
+        let TyKind::FnDef(def_id, _) = ty.kind() else {
+            return None;
+        };
+        let local_def_id = def_id.as_local()?;
+        if self.tcx.impl_of_method(*def_id).is_none() && !is_c_fn(*def_id, self.tcx) {
+            Some(local_def_id)
+        } else {
+            None
+        }
+    }
+
+    fn operand(&mut self, operand: &Operand<'tcx>) {
+        let local_def_id = some_or!(self.get_function(operand), return);
+        self.fn_ptrs.insert(local_def_id);
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for FnPtrVisitor<'tcx> {
+    fn visit_rvalue(&mut self, rvalue: &Rvalue<'tcx>, location: Location) {
+        match rvalue {
+            Rvalue::Use(v)
+            | Rvalue::Repeat(v, _)
+            | Rvalue::Cast(_, v, _)
+            | Rvalue::UnaryOp(_, v) => self.operand(v),
+            Rvalue::BinaryOp(_, box (v1, v2)) => {
+                self.operand(v1);
+                self.operand(v2);
+            }
+            Rvalue::Aggregate(_, fs) => {
+                for f in fs {
+                    self.operand(f);
+                }
+            }
+            _ => {}
+        }
+        self.super_rvalue(rvalue, location);
+    }
+}
+
+#[repr(transparent)]
+struct VecBitSet<'a, T: Idx>(&'a Vec<HybridBitSet<T>>);
+
+impl<T: Idx> DirectedGraph for VecBitSet<'_, T> {
+    type Node = T;
+
+    fn num_nodes(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl<T: Idx> Successors for VecBitSet<'_, T> {
+    fn successors(&self, node: Self::Node) -> impl Iterator<Item = Self::Node> {
+        self.0[node.index()].iter()
+    }
+}

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -517,13 +517,12 @@ fn collect_param_alias<'tcx>(
     tcx: TyCtxt<'tcx>,
 ) {
     for (skip, (_, i1)) in params.iter().enumerate() {
-        if fun_alias.contains(i1) {
-            continue;
-        }
         for (_, i2) in params.iter().skip(skip + 1) {
             let index1 = args[*i1 - 1].unwrap();
             let index2 = args[*i2 - 1].unwrap();
-            if fun_alias.contains(i2) || !check_type_deref(pre, index1, index2, tcx) {
+            if (fun_alias.contains(i1) && fun_alias.contains(i2))
+                || !check_type_deref(pre, index1, index2, tcx)
+            {
                 continue;
             }
 

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -510,7 +510,6 @@ pub fn compute_alias<'tcx>(
             let g_index = pre.var_nodes[&(local_def_id, local)].index;
 
             if (1..=*inputs).contains(&index) {
-                // In case the local is a parmeter whose type is a raw pointer
                 let ty = decl.ty;
                 let TyKind::RawPtr(..) = ty.kind() else {
                     continue;

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -119,6 +119,7 @@ pub struct AliasResults {
     pub ends: Vec<usize>,
     pub var_nodes: FxHashMap<(LocalDefId, Local), LocNode>,
     pub globals: FxHashMap<LocalDefId, usize>,
+    pub non_fn_globals: HybridBitSet<usize>,
     pub solutions: Solutions,
 }
 
@@ -550,6 +551,7 @@ pub fn compute_alias<'tcx>(
         ends: pre.index_info.ends,
         var_nodes: pre.var_nodes,
         globals: pre.globals,
+        non_fn_globals: globals,
         solutions,
     }
 }

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -534,13 +534,6 @@ pub fn compute_alias<'tcx>(
         for (i, (index, p)) in params.iter().enumerate() {
             let mut sol = solutions[*index].clone();
             sol.subtract(&locals);
-            sol.intersect(&non_fn_globals);
-
-            for s in sol.iter() {
-                if check_type(&pre, *index, s, tcx) {
-                    inv_param.entry(s).or_default().insert(*p);
-                }
-            }
 
             for (cand_index, cand_p) in params.iter().skip(i + 1) {
                 if !check_type_deref(&pre, *index, *cand_index, tcx) {
@@ -552,6 +545,14 @@ pub fn compute_alias<'tcx>(
                 if !cand_sol.is_empty() {
                     fun_alias.insert(*p);
                     fun_alias.insert(*cand_p);
+                }
+            }
+
+            sol.intersect(&non_fn_globals);
+
+            for s in sol.iter() {
+                if check_type(&pre, *index, s, tcx) {
+                    inv_param.entry(s).or_default().insert(*p);
                 }
             }
         }

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -423,11 +423,9 @@ pub fn compute_alias(
         for (index, p) in &params {
             let sol = &solutions[*index];
             for s in sol.iter() {
-                inv_param.entry(s)
-                    .or_default()
-                    .insert(*p);
+                inv_param.entry(s).or_default().insert(*p);
 
-                    if locals.contains(s) {
+                if locals.contains(s) {
                     continue;
                 }
 

--- a/src/may_analysis/bitset.rs
+++ b/src/may_analysis/bitset.rs
@@ -1,0 +1,956 @@
+// from rustc_index/src/bit_set.rs (nightly-2023-09-05)
+
+use std::{
+    fmt, iter,
+    marker::PhantomData,
+    ops::{Bound, RangeBounds},
+    slice,
+};
+
+use arrayvec::ArrayVec;
+use rustc_index::{
+    bit_set::{BitRelations, DenseBitSet},
+    Idx,
+};
+use smallvec::{smallvec, SmallVec};
+
+type Word = u64;
+const WORD_BYTES: usize = size_of::<Word>();
+const WORD_BITS: usize = WORD_BYTES * 8;
+
+#[inline]
+fn inclusive_start_end<T: Idx>(
+    range: impl RangeBounds<T>,
+    domain: usize,
+) -> Option<(usize, usize)> {
+    // Both start and end are inclusive.
+    let start = match range.start_bound().cloned() {
+        Bound::Included(start) => start.index(),
+        Bound::Excluded(start) => start.index() + 1,
+        Bound::Unbounded => 0,
+    };
+    let end = match range.end_bound().cloned() {
+        Bound::Included(end) => end.index(),
+        Bound::Excluded(end) => end.index().checked_sub(1)?,
+        Bound::Unbounded => domain - 1,
+    };
+    assert!(end < domain);
+    if start > end {
+        return None;
+    }
+    Some((start, end))
+}
+
+macro_rules! bit_relations_inherent_impls {
+    () => {
+        /// Sets `self = self | other` and returns `true` if `self` changed
+        /// (i.e., if new bits were added).
+        pub fn union<Rhs>(&mut self, other: &Rhs) -> bool
+        where Self: BitRelations<Rhs> {
+            <Self as BitRelations<Rhs>>::union(self, other)
+        }
+
+        /// Sets `self = self - other` and returns `true` if `self` changed.
+        /// (i.e., if any bits were removed).
+        pub fn subtract<Rhs>(&mut self, other: &Rhs) -> bool
+        where Self: BitRelations<Rhs> {
+            <Self as BitRelations<Rhs>>::subtract(self, other)
+        }
+
+        /// Sets `self = self & other` and return `true` if `self` changed.
+        /// (i.e., if any bits were removed).
+        pub fn intersect<Rhs>(&mut self, other: &Rhs) -> bool
+        where Self: BitRelations<Rhs> {
+            <Self as BitRelations<Rhs>>::intersect(self, other)
+        }
+    };
+}
+
+/// A fixed-size bitset type with a dense representation.
+///
+/// NOTE: Use [`GrowableBitSet`] if you need support for resizing after creation.
+///
+/// `T` is an index type, typically a newtyped `usize` wrapper, but it can also
+/// just be `usize`.
+///
+/// All operations that involve an element will panic if the element is equal
+/// to or greater than the domain size. All operations that involve two bitsets
+/// will panic if the bitsets have differing domain sizes.
+#[derive(Eq, PartialEq, Hash)]
+pub struct BitSet<T> {
+    domain_size: usize,
+    words: SmallVec<[Word; 2]>,
+    marker: PhantomData<T>,
+}
+
+impl<T> BitSet<T> {
+    /// Gets the domain size.
+    pub fn domain_size(&self) -> usize {
+        self.domain_size
+    }
+}
+
+impl<T: Idx> BitSet<T> {
+    bit_relations_inherent_impls! {}
+
+    /// Creates a new, empty bitset with a given `domain_size`.
+    #[inline]
+    pub fn new_empty(domain_size: usize) -> BitSet<T> {
+        let num_words = num_words(domain_size);
+        BitSet {
+            domain_size,
+            words: smallvec![0; num_words],
+            marker: PhantomData,
+        }
+    }
+
+    /// Creates a new, filled bitset with a given `domain_size`.
+    #[inline]
+    pub fn new_filled(domain_size: usize) -> BitSet<T> {
+        let num_words = num_words(domain_size);
+        let mut result = BitSet {
+            domain_size,
+            words: smallvec![!0; num_words],
+            marker: PhantomData,
+        };
+        result.clear_excess_bits();
+        result
+    }
+
+    /// Clear all elements.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.words.fill(0);
+    }
+
+    /// Creates a new bitset with the same elements as the rustc's `DenseBitSet`.
+    #[inline]
+    pub fn from_dense(dense: &DenseBitSet<T>) -> Self {
+        // println!("from dense {:?}", dense);
+        let mut result = BitSet::new_empty(dense.domain_size());
+        for elem in dense.iter() {
+            result.insert(elem);
+        }
+        // println!("to bitset  {:?}", result);
+        result
+    }
+
+    /// Clear excess bits in the final word.
+    fn clear_excess_bits(&mut self) {
+        clear_excess_bits_in_final_word(self.domain_size, &mut self.words);
+    }
+
+    /// Count the number of set bits in the set.
+    pub fn count(&self) -> usize {
+        self.words.iter().map(|e| e.count_ones() as usize).sum()
+    }
+
+    /// Returns `true` if `self` contains `elem`.
+    #[inline]
+    pub fn contains(&self, elem: T) -> bool {
+        assert!(elem.index() < self.domain_size);
+        let (word_index, mask) = word_index_and_mask(elem);
+        (self.words[word_index] & mask) != 0
+    }
+
+    /// Is `self` is a (non-strict) superset of `other`?
+    #[inline]
+    pub fn superset(&self, other: &BitSet<T>) -> bool {
+        assert_eq!(self.domain_size, other.domain_size);
+        self.words
+            .iter()
+            .zip(&other.words)
+            .all(|(a, b)| (a & b) == *b)
+    }
+
+    /// Is the set empty?
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.words.iter().all(|a| *a == 0)
+    }
+
+    /// Insert `elem`. Returns whether the set has changed.
+    #[inline]
+    pub fn insert(&mut self, elem: T) -> bool {
+        assert!(elem.index() < self.domain_size);
+        let (word_index, mask) = word_index_and_mask(elem);
+        let word_ref = &mut self.words[word_index];
+        let word = *word_ref;
+        let new_word = word | mask;
+        *word_ref = new_word;
+        new_word != word
+    }
+
+    #[inline]
+    pub fn insert_range(&mut self, elems: impl RangeBounds<T>) {
+        let Some((start, end)) = inclusive_start_end(elems, self.domain_size) else {
+            return;
+        };
+
+        let (start_word_index, start_mask) = word_index_and_mask(start);
+        let (end_word_index, end_mask) = word_index_and_mask(end);
+
+        // Set all words in between start and end (exclusively of both).
+        for word_index in (start_word_index + 1)..end_word_index {
+            self.words[word_index] = !0;
+        }
+
+        if start_word_index != end_word_index {
+            // Start and end are in different words, so we handle each in turn.
+            //
+            // We set all leading bits. This includes the start_mask bit.
+            self.words[start_word_index] |= !(start_mask - 1);
+            // And all trailing bits (i.e. from 0..=end) in the end word,
+            // including the end.
+            self.words[end_word_index] |= end_mask | (end_mask - 1);
+        } else {
+            self.words[start_word_index] |= end_mask | (end_mask - start_mask);
+        }
+    }
+
+    /// Sets all bits to true.
+    pub fn insert_all(&mut self) {
+        self.words.fill(!0);
+        self.clear_excess_bits();
+    }
+
+    /// Returns `true` if the set has changed.
+    #[inline]
+    pub fn remove(&mut self, elem: T) -> bool {
+        assert!(elem.index() < self.domain_size);
+        let (word_index, mask) = word_index_and_mask(elem);
+        let word_ref = &mut self.words[word_index];
+        let word = *word_ref;
+        let new_word = word & !mask;
+        *word_ref = new_word;
+        new_word != word
+    }
+
+    /// Gets a slice of the underlying words.
+    pub fn words(&self) -> &[Word] {
+        &self.words
+    }
+
+    /// Iterates over the indices of set bits in a sorted order.
+    #[inline]
+    pub fn iter(&self) -> BitIter<'_, T> {
+        BitIter::new(&self.words)
+    }
+
+    /// Duplicates the set as a hybrid set.
+    pub fn to_hybrid(&self) -> HybridBitSet<T> {
+        // Note: we currently don't bother trying to make a Sparse set.
+        HybridBitSet::Dense(self.to_owned())
+    }
+
+    /// Set `self = self | other`. In contrast to `union` returns `true` if the set contains at
+    /// least one bit that is not in `other` (i.e. `other` is not a superset of `self`).
+    ///
+    /// This is an optimization for union of a hybrid bitset.
+    fn reverse_union_sparse(&mut self, sparse: &SparseBitSet<T>) -> bool {
+        assert!(sparse.domain_size == self.domain_size);
+        self.clear_excess_bits();
+
+        let mut not_already = false;
+        // Index of the current word not yet merged.
+        let mut current_index = 0;
+        // Mask of bits that came from the sparse set in the current word.
+        let mut new_bit_mask = 0;
+        for (word_index, mask) in sparse.iter().map(|x| word_index_and_mask(*x)) {
+            // Next bit is in a word not inspected yet.
+            if word_index > current_index {
+                self.words[current_index] |= new_bit_mask;
+                // Were there any bits in the old word that did not occur in the sparse set?
+                not_already |= (self.words[current_index] ^ new_bit_mask) != 0;
+                // Check all words we skipped for any set bit.
+                not_already |= self.words[current_index + 1..word_index]
+                    .iter()
+                    .any(|&x| x != 0);
+                // Update next word.
+                current_index = word_index;
+                // Reset bit mask, no bits have been merged yet.
+                new_bit_mask = 0;
+            }
+            // Add bit and mark it as coming from the sparse set.
+            // self.words[word_index] |= mask;
+            new_bit_mask |= mask;
+        }
+        self.words[current_index] |= new_bit_mask;
+        // Any bits in the last inspected word that were not in the sparse set?
+        not_already |= (self.words[current_index] ^ new_bit_mask) != 0;
+        // Any bits in the tail? Note `clear_excess_bits` before.
+        not_already |= self.words[current_index + 1..].iter().any(|&x| x != 0);
+
+        not_already
+    }
+
+    fn last_set_in(&self, range: impl RangeBounds<T>) -> Option<T> {
+        let (start, end) = inclusive_start_end(range, self.domain_size)?;
+        let (start_word_index, _) = word_index_and_mask(start);
+        let (end_word_index, end_mask) = word_index_and_mask(end);
+
+        let end_word = self.words[end_word_index] & (end_mask | (end_mask - 1));
+        if end_word != 0 {
+            let pos = max_bit(end_word) + WORD_BITS * end_word_index;
+            if start <= pos {
+                return Some(T::new(pos));
+            }
+        }
+
+        // We exclude end_word_index from the range here, because we don't want
+        // to limit ourselves to *just* the last word: the bits set it in may be
+        // after `end`, so it may not work out.
+        if let Some(offset) = self.words[start_word_index..end_word_index]
+            .iter()
+            .rposition(|&w| w != 0)
+        {
+            let word_idx = start_word_index + offset;
+            let start_word = self.words[word_idx];
+            let pos = max_bit(start_word) + WORD_BITS * word_idx;
+            if start <= pos {
+                return Some(T::new(pos));
+            }
+        }
+
+        None
+    }
+}
+
+// dense REL dense
+impl<T: Idx> BitRelations<BitSet<T>> for BitSet<T> {
+    fn union(&mut self, other: &BitSet<T>) -> bool {
+        assert_eq!(self.domain_size, other.domain_size);
+        bitwise(&mut self.words, &other.words, |a, b| a | b)
+    }
+
+    fn subtract(&mut self, other: &BitSet<T>) -> bool {
+        assert_eq!(self.domain_size, other.domain_size);
+        bitwise(&mut self.words, &other.words, |a, b| a & !b)
+    }
+
+    fn intersect(&mut self, other: &BitSet<T>) -> bool {
+        assert_eq!(self.domain_size, other.domain_size);
+        bitwise(&mut self.words, &other.words, |a, b| a & b)
+    }
+}
+
+// Applies a function to mutate a bitset, and returns true if any
+// of the applications return true
+fn sequential_update<T: Idx>(
+    mut self_update: impl FnMut(T) -> bool,
+    it: impl Iterator<Item = T>,
+) -> bool {
+    it.fold(false, |changed, elem| self_update(elem) | changed)
+}
+
+// Optimization of intersection for SparseBitSet that's generic
+// over the RHS
+fn sparse_intersect<T: Idx>(
+    set: &mut SparseBitSet<T>,
+    other_contains: impl Fn(&T) -> bool,
+) -> bool {
+    let size = set.elems.len();
+    set.elems.retain(|elem| other_contains(elem));
+    set.elems.len() != size
+}
+
+// Optimization of dense/sparse intersection. The resulting set is
+// guaranteed to be at most the size of the sparse set, and hence can be
+// represented as a sparse set. Therefore the sparse set is copied and filtered,
+// then returned as the new set.
+fn dense_sparse_intersect<T: Idx>(
+    dense: &BitSet<T>,
+    sparse: &SparseBitSet<T>,
+) -> (SparseBitSet<T>, bool) {
+    let mut sparse_copy = sparse.clone();
+    sparse_intersect(&mut sparse_copy, |el| dense.contains(*el));
+    let n = sparse_copy.len();
+    (sparse_copy, n != dense.count())
+}
+
+// hybrid REL dense
+impl<T: Idx> BitRelations<BitSet<T>> for HybridBitSet<T> {
+    fn union(&mut self, other: &BitSet<T>) -> bool {
+        assert_eq!(self.domain_size(), other.domain_size);
+        match self {
+            HybridBitSet::Sparse(sparse) => {
+                // `self` is sparse and `other` is dense. To
+                // merge them, we have two available strategies:
+                // * Densify `self` then merge other
+                // * Clone other then integrate bits from `self`
+                // The second strategy requires dedicated method
+                // since the usual `union` returns the wrong
+                // result. In the dedicated case the computation
+                // is slightly faster if the bits of the sparse
+                // bitset map to only few words of the dense
+                // representation, i.e. indices are near each
+                // other.
+                //
+                // Benchmarking seems to suggest that the second
+                // option is worth it.
+                let mut new_dense = other.clone();
+                let changed = new_dense.reverse_union_sparse(sparse);
+                *self = HybridBitSet::Dense(new_dense);
+                changed
+            }
+
+            HybridBitSet::Dense(dense) => dense.union(other),
+        }
+    }
+
+    fn subtract(&mut self, other: &BitSet<T>) -> bool {
+        assert_eq!(self.domain_size(), other.domain_size);
+        match self {
+            HybridBitSet::Sparse(sparse) => {
+                sequential_update(|elem| sparse.remove(elem), other.iter())
+            }
+            HybridBitSet::Dense(dense) => dense.subtract(other),
+        }
+    }
+
+    fn intersect(&mut self, other: &BitSet<T>) -> bool {
+        assert_eq!(self.domain_size(), other.domain_size);
+        match self {
+            HybridBitSet::Sparse(sparse) => sparse_intersect(sparse, |elem| other.contains(*elem)),
+            HybridBitSet::Dense(dense) => dense.intersect(other),
+        }
+    }
+}
+
+// dense REL hybrid
+impl<T: Idx> BitRelations<HybridBitSet<T>> for BitSet<T> {
+    fn union(&mut self, other: &HybridBitSet<T>) -> bool {
+        assert_eq!(self.domain_size, other.domain_size());
+        match other {
+            HybridBitSet::Sparse(sparse) => {
+                sequential_update(|elem| self.insert(elem), sparse.iter().cloned())
+            }
+            HybridBitSet::Dense(dense) => self.union(dense),
+        }
+    }
+
+    fn subtract(&mut self, other: &HybridBitSet<T>) -> bool {
+        assert_eq!(self.domain_size, other.domain_size());
+        match other {
+            HybridBitSet::Sparse(sparse) => {
+                sequential_update(|elem| self.remove(elem), sparse.iter().cloned())
+            }
+            HybridBitSet::Dense(dense) => self.subtract(dense),
+        }
+    }
+
+    fn intersect(&mut self, other: &HybridBitSet<T>) -> bool {
+        assert_eq!(self.domain_size, other.domain_size());
+        match other {
+            HybridBitSet::Sparse(sparse) => {
+                let (updated, changed) = dense_sparse_intersect(self, sparse);
+
+                // We can't directly assign the SparseBitSet to the BitSet, and
+                // doing `*self = updated.to_dense()` would cause a drop / reallocation. Instead,
+                // the BitSet is cleared and `updated` is copied into `self`.
+                self.clear();
+                for elem in updated.iter() {
+                    self.insert(*elem);
+                }
+                changed
+            }
+            HybridBitSet::Dense(dense) => self.intersect(dense),
+        }
+    }
+}
+
+// hybrid REL hybrid
+impl<T: Idx> BitRelations<HybridBitSet<T>> for HybridBitSet<T> {
+    fn union(&mut self, other: &HybridBitSet<T>) -> bool {
+        assert_eq!(self.domain_size(), other.domain_size());
+        match self {
+            HybridBitSet::Sparse(_) => {
+                match other {
+                    HybridBitSet::Sparse(other_sparse) => {
+                        // Both sets are sparse. Add the elements in
+                        // `other_sparse` to `self` one at a time. This
+                        // may or may not cause `self` to be densified.
+                        let mut changed = false;
+                        for elem in other_sparse.iter() {
+                            changed |= self.insert(*elem);
+                        }
+                        changed
+                    }
+
+                    HybridBitSet::Dense(other_dense) => self.union(other_dense),
+                }
+            }
+
+            HybridBitSet::Dense(self_dense) => self_dense.union(other),
+        }
+    }
+
+    fn subtract(&mut self, other: &HybridBitSet<T>) -> bool {
+        assert_eq!(self.domain_size(), other.domain_size());
+        match self {
+            HybridBitSet::Sparse(self_sparse) => {
+                sequential_update(|elem| self_sparse.remove(elem), other.iter())
+            }
+            HybridBitSet::Dense(self_dense) => self_dense.subtract(other),
+        }
+    }
+
+    fn intersect(&mut self, other: &HybridBitSet<T>) -> bool {
+        assert_eq!(self.domain_size(), other.domain_size());
+        match self {
+            HybridBitSet::Sparse(self_sparse) => {
+                sparse_intersect(self_sparse, |elem| other.contains(*elem))
+            }
+            HybridBitSet::Dense(self_dense) => match other {
+                HybridBitSet::Sparse(other_sparse) => {
+                    let (updated, changed) = dense_sparse_intersect(self_dense, other_sparse);
+                    *self = HybridBitSet::Sparse(updated);
+                    changed
+                }
+                HybridBitSet::Dense(other_dense) => self_dense.intersect(other_dense),
+            },
+        }
+    }
+}
+
+impl<T> Clone for BitSet<T> {
+    fn clone(&self) -> Self {
+        BitSet {
+            domain_size: self.domain_size,
+            words: self.words.clone(),
+            marker: PhantomData,
+        }
+    }
+
+    fn clone_from(&mut self, from: &Self) {
+        self.domain_size = from.domain_size;
+        self.words.clone_from(&from.words);
+    }
+}
+
+impl<T: Idx> fmt::Debug for BitSet<T> {
+    fn fmt(&self, w: &mut fmt::Formatter<'_>) -> fmt::Result {
+        w.debug_list().entries(self.iter()).finish()
+    }
+}
+
+impl<T: Idx> fmt::Display for BitSet<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut sep = '[';
+
+        // Note: this is a little endian printout of bytes.
+
+        // i tracks how many bits we have printed so far.
+        let mut i = 0;
+        for word in &self.words {
+            let mut word = *word;
+            for _ in 0..WORD_BYTES {
+                let remain = self.domain_size - i;
+                // If less than a byte remains, then mask just that many bits.
+                let mask = if remain <= 8 { (1 << remain) - 1 } else { 0xFF };
+                debug_assert!(mask <= 0xFF);
+                let byte = word & mask;
+
+                write!(f, "{sep}{byte:02x}")?;
+
+                if remain <= 8 {
+                    break;
+                }
+                word >>= 8;
+                i += 8;
+                sep = '-';
+            }
+            sep = '|';
+        }
+
+        write!(f, "]")
+    }
+}
+
+#[derive(Debug)]
+pub struct BitIter<'a, T: Idx> {
+    /// A copy of the current word, but with any already-visited bits cleared.
+    /// (This lets us use `trailing_zeros()` to find the next set bit.) When it
+    /// is reduced to 0, we move onto the next word.
+    word: Word,
+
+    /// The offset (measured in bits) of the current word.
+    offset: usize,
+
+    /// Underlying iterator over the words.
+    iter: slice::Iter<'a, Word>,
+
+    marker: PhantomData<T>,
+}
+
+impl<'a, T: Idx> BitIter<'a, T> {
+    #[inline]
+    fn new(words: &'a [Word]) -> BitIter<'a, T> {
+        // We initialize `word` and `offset` to degenerate values. On the first
+        // call to `next()` we will fall through to getting the first word from
+        // `iter`, which sets `word` to the first word (if there is one) and
+        // `offset` to 0. Doing it this way saves us from having to maintain
+        // additional state about whether we have started.
+        BitIter {
+            word: 0,
+            offset: usize::MAX - (WORD_BITS - 1),
+            iter: words.iter(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T: Idx> Iterator for BitIter<'_, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        loop {
+            if self.word != 0 {
+                // Get the position of the next set bit in the current word,
+                // then clear the bit.
+                let bit_pos = self.word.trailing_zeros() as usize;
+                let bit = 1 << bit_pos;
+                self.word ^= bit;
+                return Some(T::new(bit_pos + self.offset));
+            }
+
+            // Move onto the next word. `wrapping_add()` is needed to handle
+            // the degenerate initial value given to `offset` in `new()`.
+            let word = self.iter.next()?;
+            self.word = *word;
+            self.offset = self.offset.wrapping_add(WORD_BITS);
+        }
+    }
+}
+
+#[inline]
+fn bitwise<Op>(out_vec: &mut [Word], in_vec: &[Word], op: Op) -> bool
+where Op: Fn(Word, Word) -> Word {
+    assert_eq!(out_vec.len(), in_vec.len());
+    let mut changed = 0;
+    for (out_elem, in_elem) in iter::zip(out_vec, in_vec) {
+        let old_val = *out_elem;
+        let new_val = op(old_val, *in_elem);
+        *out_elem = new_val;
+        // This is essentially equivalent to a != with changed being a bool, but
+        // in practice this code gets auto-vectorized by the compiler for most
+        // operators. Using != here causes us to generate quite poor code as the
+        // compiler tries to go back to a boolean on each loop iteration.
+        changed |= old_val ^ new_val;
+    }
+    changed != 0
+}
+
+const SPARSE_MAX: usize = 8;
+
+/// A fixed-size bitset type with a sparse representation and a maximum of
+/// `SPARSE_MAX` elements. The elements are stored as a sorted `ArrayVec` with
+/// no duplicates.
+///
+/// This type is used by `HybridBitSet`; do not use directly.
+#[derive(Clone, Debug)]
+pub struct SparseBitSet<T> {
+    domain_size: usize,
+    elems: ArrayVec<T, SPARSE_MAX>,
+}
+
+impl<T: Idx> SparseBitSet<T> {
+    bit_relations_inherent_impls! {}
+
+    fn new_empty(domain_size: usize) -> Self {
+        SparseBitSet {
+            domain_size,
+            elems: ArrayVec::new(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.elems.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.elems.len() == 0
+    }
+
+    fn contains(&self, elem: T) -> bool {
+        assert!(elem.index() < self.domain_size);
+        self.elems.contains(&elem)
+    }
+
+    fn insert(&mut self, elem: T) -> bool {
+        assert!(elem.index() < self.domain_size);
+        let changed = if let Some(i) = self.elems.iter().position(|&e| e.index() >= elem.index()) {
+            if self.elems[i] == elem {
+                // `elem` is already in the set.
+                false
+            } else {
+                // `elem` is smaller than one or more existing elements.
+                self.elems.insert(i, elem);
+                true
+            }
+        } else {
+            // `elem` is larger than all existing elements.
+            self.elems.push(elem);
+            true
+        };
+        assert!(self.len() <= SPARSE_MAX);
+        changed
+    }
+
+    fn remove(&mut self, elem: T) -> bool {
+        assert!(elem.index() < self.domain_size);
+        if let Some(i) = self.elems.iter().position(|&e| e == elem) {
+            self.elems.remove(i);
+            true
+        } else {
+            false
+        }
+    }
+
+    fn to_dense(&self) -> BitSet<T> {
+        let mut dense = BitSet::new_empty(self.domain_size);
+        for elem in self.elems.iter() {
+            dense.insert(*elem);
+        }
+        dense
+    }
+
+    fn iter(&self) -> slice::Iter<'_, T> {
+        self.elems.iter()
+    }
+}
+
+impl<T: Idx + Ord> SparseBitSet<T> {
+    fn last_set_in(&self, range: impl RangeBounds<T>) -> Option<T> {
+        let mut last_leq = None;
+        for e in self.iter() {
+            if range.contains(e) {
+                last_leq = Some(*e);
+            }
+        }
+        last_leq
+    }
+}
+
+/// A fixed-size bitset type with a hybrid representation: sparse when there
+/// are up to a `SPARSE_MAX` elements in the set, but dense when there are more
+/// than `SPARSE_MAX`.
+///
+/// This type is especially efficient for sets that typically have a small
+/// number of elements, but a large `domain_size`, and are cleared frequently.
+///
+/// `T` is an index type, typically a newtyped `usize` wrapper, but it can also
+/// just be `usize`.
+///
+/// All operations that involve an element will panic if the element is equal
+/// to or greater than the domain size. All operations that involve two bitsets
+/// will panic if the bitsets have differing domain sizes.
+#[derive(Clone)]
+pub enum HybridBitSet<T> {
+    Sparse(SparseBitSet<T>),
+    Dense(BitSet<T>),
+}
+
+impl<T: Idx> fmt::Debug for HybridBitSet<T> {
+    fn fmt(&self, w: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Sparse(b) => b.fmt(w),
+            Self::Dense(b) => b.fmt(w),
+        }
+    }
+}
+
+impl<T: Idx> HybridBitSet<T> {
+    bit_relations_inherent_impls! {}
+
+    pub fn new_empty(domain_size: usize) -> Self {
+        HybridBitSet::Sparse(SparseBitSet::new_empty(domain_size))
+    }
+
+    pub fn from_dense(dense: &DenseBitSet<T>) -> Self {
+        HybridBitSet::Dense(BitSet::from_dense(dense))
+    }
+
+    pub fn domain_size(&self) -> usize {
+        match self {
+            HybridBitSet::Sparse(sparse) => sparse.domain_size,
+            HybridBitSet::Dense(dense) => dense.domain_size,
+        }
+    }
+
+    pub fn clear(&mut self) {
+        let domain_size = self.domain_size();
+        *self = HybridBitSet::new_empty(domain_size);
+    }
+
+    pub fn contains(&self, elem: T) -> bool {
+        match self {
+            HybridBitSet::Sparse(sparse) => sparse.contains(elem),
+            HybridBitSet::Dense(dense) => dense.contains(elem),
+        }
+    }
+
+    pub fn superset(&self, other: &HybridBitSet<T>) -> bool {
+        match (self, other) {
+            (HybridBitSet::Dense(self_dense), HybridBitSet::Dense(other_dense)) => {
+                self_dense.superset(other_dense)
+            }
+            _ => {
+                assert!(self.domain_size() == other.domain_size());
+                other.iter().all(|elem| self.contains(elem))
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            HybridBitSet::Sparse(sparse) => sparse.is_empty(),
+            HybridBitSet::Dense(dense) => dense.is_empty(),
+        }
+    }
+
+    /// Returns the previous element present in the bitset from `elem`,
+    /// inclusively of elem. That is, will return `Some(elem)` if elem is in the
+    /// bitset.
+    pub fn last_set_in(&self, range: impl RangeBounds<T>) -> Option<T>
+    where T: Ord {
+        match self {
+            HybridBitSet::Sparse(sparse) => sparse.last_set_in(range),
+            HybridBitSet::Dense(dense) => dense.last_set_in(range),
+        }
+    }
+
+    pub fn insert(&mut self, elem: T) -> bool {
+        // No need to check `elem` against `self.domain_size` here because all
+        // the match cases check it, one way or another.
+        match self {
+            HybridBitSet::Sparse(sparse) if sparse.len() < SPARSE_MAX => {
+                // The set is sparse and has space for `elem`.
+                sparse.insert(elem)
+            }
+            HybridBitSet::Sparse(sparse) if sparse.contains(elem) => {
+                // The set is sparse and does not have space for `elem`, but
+                // that doesn't matter because `elem` is already present.
+                false
+            }
+            HybridBitSet::Sparse(sparse) => {
+                // The set is sparse and full. Convert to a dense set.
+                let mut dense = sparse.to_dense();
+                let changed = dense.insert(elem);
+                assert!(changed);
+                *self = HybridBitSet::Dense(dense);
+                changed
+            }
+            HybridBitSet::Dense(dense) => dense.insert(elem),
+        }
+    }
+
+    pub fn insert_range(&mut self, elems: impl RangeBounds<T>) {
+        // No need to check `elem` against `self.domain_size` here because all
+        // the match cases check it, one way or another.
+        let start = match elems.start_bound().cloned() {
+            Bound::Included(start) => start.index(),
+            Bound::Excluded(start) => start.index() + 1,
+            Bound::Unbounded => 0,
+        };
+        let end = match elems.end_bound().cloned() {
+            Bound::Included(end) => end.index() + 1,
+            Bound::Excluded(end) => end.index(),
+            Bound::Unbounded => self.domain_size() - 1,
+        };
+        let Some(len) = end.checked_sub(start) else {
+            return;
+        };
+        match self {
+            HybridBitSet::Sparse(sparse) if sparse.len() + len < SPARSE_MAX => {
+                // The set is sparse and has space for `elems`.
+                for elem in start..end {
+                    sparse.insert(T::new(elem));
+                }
+            }
+            HybridBitSet::Sparse(sparse) => {
+                // The set is sparse and full. Convert to a dense set.
+                let mut dense = sparse.to_dense();
+                dense.insert_range(elems);
+                *self = HybridBitSet::Dense(dense);
+            }
+            HybridBitSet::Dense(dense) => dense.insert_range(elems),
+        }
+    }
+
+    pub fn insert_all(&mut self) {
+        let domain_size = self.domain_size();
+        match self {
+            HybridBitSet::Sparse(_) => {
+                *self = HybridBitSet::Dense(BitSet::new_filled(domain_size));
+            }
+            HybridBitSet::Dense(dense) => dense.insert_all(),
+        }
+    }
+
+    pub fn remove(&mut self, elem: T) -> bool {
+        // Note: we currently don't bother going from Dense back to Sparse.
+        match self {
+            HybridBitSet::Sparse(sparse) => sparse.remove(elem),
+            HybridBitSet::Dense(dense) => dense.remove(elem),
+        }
+    }
+
+    /// Converts to a dense set, consuming itself in the process.
+    pub fn to_dense(self) -> BitSet<T> {
+        match self {
+            HybridBitSet::Sparse(sparse) => sparse.to_dense(),
+            HybridBitSet::Dense(dense) => dense,
+        }
+    }
+
+    pub fn iter(&self) -> HybridIter<'_, T> {
+        match self {
+            HybridBitSet::Sparse(sparse) => HybridIter::Sparse(sparse.iter()),
+            HybridBitSet::Dense(dense) => HybridIter::Dense(dense.iter()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum HybridIter<'a, T: Idx> {
+    Sparse(slice::Iter<'a, T>),
+    Dense(BitIter<'a, T>),
+}
+
+impl<T: Idx> Iterator for HybridIter<'_, T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        match self {
+            HybridIter::Sparse(sparse) => sparse.next().copied(),
+            HybridIter::Dense(dense) => dense.next(),
+        }
+    }
+}
+
+#[inline]
+fn num_words<T: Idx>(domain_size: T) -> usize {
+    domain_size.index().div_ceil(WORD_BITS)
+}
+
+#[inline]
+fn word_index_and_mask<T: Idx>(elem: T) -> (usize, Word) {
+    let elem = elem.index();
+    let word_index = elem / WORD_BITS;
+    let mask = 1 << (elem % WORD_BITS);
+    (word_index, mask)
+}
+
+fn clear_excess_bits_in_final_word(domain_size: usize, words: &mut [Word]) {
+    let num_bits_in_final_word = domain_size % WORD_BITS;
+    if num_bits_in_final_word > 0 {
+        let mask = (1 << num_bits_in_final_word) - 1;
+        words[words.len() - 1] &= mask;
+    }
+}
+
+#[inline]
+fn max_bit(word: Word) -> usize {
+    WORD_BITS - 1 - word.leading_zeros() as usize
+}

--- a/src/may_analysis/mod.rs
+++ b/src/may_analysis/mod.rs
@@ -1,0 +1,6 @@
+pub mod alloc_finder;
+pub mod analysis;
+pub mod bitset;
+pub mod ty_shape;
+#[cfg(test)]
+mod tests;

--- a/src/may_analysis/mod.rs
+++ b/src/may_analysis/mod.rs
@@ -1,6 +1,6 @@
 pub mod alloc_finder;
 pub mod analysis;
 pub mod bitset;
-pub mod ty_shape;
 #[cfg(test)]
 mod tests;
+pub mod ty_shape;

--- a/src/may_analysis/tests.rs
+++ b/src/may_analysis/tests.rs
@@ -1,0 +1,2877 @@
+use std::collections::HashMap;
+
+use rustc_index::Idx;
+use rustc_middle::{
+    mir::{BasicBlock, Location},
+    ty::TyCtxt,
+};
+use rustc_span::def_id::LocalDefId;
+use typed_arena::Arena;
+
+use super::{analysis::*, bitset::HybridBitSet, ty_shape::*};
+use crate::compile_util;
+
+/// To inspect the MIR of test cases, you can:
+
+/// - Look at the compiled MIR code in the comments of the test case functions, or
+/// - Uncomment the line:
+/// ```rust
+/// println!("{}", compile_util::body_to_str(item.body));
+/// ```
+/// inside the `analyze` function in `src/may_analysis/mod.rs` and run the test cases.
+///
+///
+/// 1. `AnalysisResults.ends`
+///
+/// Each local variable in an MIR body is assigned one or more indices in the
+/// analysis, representing its location(s) in the points-to graph.
+///
+/// The indices are assigned in the following order:
+///
+/// - Function arguments
+/// - Return value
+/// - Remaining local variables (in the order they are declared, i.e., by name:
+///   `_1`, `_2`, ...)
+///
+/// If a local variable has a struct type, each of its fields is assigned a
+/// separate index.  For example, a struct with three fields will occupy three
+/// consecutive indices-say, `1`, `2`, and `3`.  The next local variable will
+/// then start at index `4`.
+///
+/// Each index corresponds to a specific "location", and every location has an
+/// associated "end": the furthest location that is reachable from it.
+///
+/// - For most locations, the "end" is simply the location itself.
+/// - However, for struct variables, the index of the first field is treated as
+///   representing the entire struct. Its "end" is updated to point to the last
+///   field of the struct, marking the span of the entire struct.
+///
+/// The `AnalysisResults.ends` vector record this mapping:
+///
+/// ```
+/// AnalysisResults.ends[<index of the location>] = <index of the end of that location>
+/// ```
+///
+/// Example assertion:
+///
+/// ```
+/// assert_eq!(res.ends, vec![0, 1, 2, 5, 4, 5, 6, 7, 8, 9]);
+/// ```
+///
+///
+/// 2. `AnalysisResults.solutions`
+///
+/// The `AnalysisResults.solutions` vector maps each location index to the set
+/// of locations it may point to-a conservative union of all points-to targets.
+///
+/// You can write assertions like:
+///
+/// ```
+/// assert_eq!(sol(&res, <index of the location>), <expected set of indices of locations>);
+/// ```
+///
+///
+/// 3. `AnalysisResults.writes`
+///
+/// `AnalysisResults.writes` records statements that perform memory writes,
+/// mapping each statement to the set of written locations.
+///
+/// Only locations that are "pointable" (i.e., appear in any `solutions` set,
+/// directly or via their `ends` range) are included. For example, if `4` is
+/// a pointable location and `ends[4] = 5`, then `5` is also considered pointable.
+///
+/// Each statement is identified by a `(block, statement_index)` pair:
+/// - `block`: the index of the basic block
+/// - `statement_index`: the index of the statement within that basic block
+///
+/// Note: Some statements (e.g., function calls) act as **terminators** in MIR
+/// and implicitly end the current basic block. As a result, even if
+/// statement appear sequential in MIR source, they may belong to different
+/// basic blocks.
+///
+/// ```
+/// assert_eq!(wg(&w, <basic block index>, <statement index>), <expected set of written location indices>);
+/// ```
+///
+/// 4. `AnalysisResults.bitfield_writes`
+///
+/// MIR statements that write to bitfields are recorded in the
+/// `AnalysisResults.bitfield_writes` map, which maps statement locations to the
+/// set of written bitfield indices.
+///
+/// Bitfields are declared in struct definitions, using the
+/// `#[bitfield(name=...)]` macro.  Bitfield indices are assigned after the
+/// regular struct fields, in the order they are declared.
+///
+/// Bitfield writes are easy to notice, as they always use generated setter
+/// functions.
+///
+/// ```
+/// assert_eq!(bw(&w, <basic block index>, <statement index>), <expected set of indices of written bitfields>);
+
+fn run_compiler<F: FnOnce(TyCtxt<'_>) + Send>(code: &str, f: F) {
+    let input = compile_util::str_to_input(code);
+    let config = compile_util::make_config(input);
+    compile_util::run_compiler(config, f).unwrap_or_else(|e| e.raise());
+}
+
+fn analyze_fn_with<F>(types: &str, params: &str, code: &str, f: F)
+where F: FnOnce(AnalysisResults, TyCtxt<'_>) + Send {
+    let name = "f";
+    let code = format!(
+        "
+        extern crate libc;
+        #[macro_use]
+        extern crate c2rust_bitfields;
+        extern \"C\" {{
+            fn malloc(_: libc::c_ulong) -> *mut libc::c_void;
+        }}
+        {}
+        unsafe extern \"C\" fn {}({}) {{
+            {}
+        }}
+    ",
+        types, name, params, code
+    );
+    run_compiler(&code, |tcx| {
+        let arena = Arena::new();
+        let tss = get_ty_shapes(&arena, tcx);
+        let pre = pre_analyze(&tss, tcx);
+        let solutions = analyze(&pre, &tss, tcx);
+        f(post_analyze(pre, solutions, &tss, tcx), tcx)
+    });
+}
+
+fn analyze_fn<F>(code: &str, f: F)
+where F: FnOnce(AnalysisResults, TyCtxt<'_>) + Send {
+    analyze_fn_with("", "", code, f);
+}
+
+fn find(name: &str, tcx: TyCtxt<'_>) -> LocalDefId {
+    tcx.hir_free_items()
+        .find_map(|item_id| {
+            let item = tcx.hir_item(item_id);
+            if item.ident.name.as_str() != name {
+                return None;
+            }
+            Some(item_id.owner_id.def_id)
+        })
+        .unwrap()
+}
+
+fn sol(res: &AnalysisResults, i: usize) -> Vec<usize> {
+    res.solutions[i].iter().collect()
+}
+
+fn v(i: usize) -> Vec<usize> {
+    (0..=i).collect()
+}
+
+fn e() -> Vec<usize> {
+    Vec::new()
+}
+
+#[test]
+fn test_eq_ref() {
+    // _1 = const 0_i32
+    // _3 = &mut _1
+    // _2 = &raw mut (*_3)
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: *mut libc::c_int = &mut x;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(3));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![1]);
+        },
+    );
+}
+
+#[test]
+fn test_eq() {
+    // _1 = const 0_i32
+    // _2 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _4 = &mut _1
+    // _3 = &raw mut (*_4)
+    // _2 = _3
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut z: *mut libc::c_int = 0 as *mut libc::c_int;
+        let mut y: *mut libc::c_int = &mut x;
+        z = y;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(4));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![1]);
+        },
+    );
+}
+
+#[test]
+fn test_eq_two() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _4 = &mut _1
+    // _3 = &raw mut (*_4)
+    // _5 = _3
+    // _7 = &mut _2
+    // _6 = &raw mut (*_7)
+    // _3 = move _6
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        let mut z: *mut libc::c_int = &mut x;
+        let mut w: *mut libc::c_int = z;
+        z = &mut y;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(7));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![1, 2]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![1, 2]);
+            assert_eq!(sol(&res, 6), vec![2]);
+            assert_eq!(sol(&res, 7), vec![2]);
+        },
+    );
+}
+
+#[test]
+fn test_eq_propagate() {
+    // _1 = const 0_i32
+    // _2 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _3 = _2
+    // _4 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _4 = _3
+    // _6 = &mut _1
+    // _5 = &raw mut (*_6)
+    // _2 = move _5
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: *mut libc::c_int = 0 as *mut libc::c_int;
+        let mut z: *mut libc::c_int = y;
+        let mut w: *mut libc::c_int = 0 as *mut libc::c_int;
+        w = z;
+        y = &mut x;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(6));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![1]);
+        },
+    );
+}
+
+#[test]
+fn test_eq_deref() {
+    // _1 = const 0_i32
+    // _3 = &mut _1
+    // _2 = &raw mut (*_3)
+    // _5 = &mut _2
+    // _4 = &raw mut (*_5)
+    // _6 = (*_4)
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: *mut libc::c_int = &mut x;
+        let mut z: *mut *mut libc::c_int = &mut y;
+        let mut w: *mut libc::c_int = *z;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(6));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![2]);
+            assert_eq!(sol(&res, 5), vec![2]);
+            assert_eq!(sol(&res, 6), vec![1]);
+        },
+    );
+}
+
+#[test]
+fn test_eq_deref_subset() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _4 = &mut _1
+    // _3 = &raw mut (*_4)
+    // _6 = &mut _3
+    // _5 = &raw mut (*_6)
+    // _8 = &mut _2
+    // _7 = &raw mut (*_8)
+    // _9 = (*_5)
+    // _7 = move _9
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        let mut z: *mut libc::c_int = &mut x;
+        let mut w: *mut *mut libc::c_int = &mut z;
+        let mut v: *mut libc::c_int = &mut y;
+        v = *w;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(9));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![3]);
+            assert_eq!(sol(&res, 6), vec![3]);
+            assert_eq!(sol(&res, 7), vec![1, 2]);
+            assert_eq!(sol(&res, 8), vec![2]);
+            assert_eq!(sol(&res, 9), vec![1]);
+        },
+    );
+}
+
+#[test]
+fn test_eq_deref_propagate() {
+    // _1 = const 0_i32
+    // _3 = &mut _1
+    // _2 = &raw mut (*_3)
+    // _5 = &mut _2
+    // _4 = &raw mut (*_5)
+    // _6 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _7 = _6
+    // _8 = (*_4)
+    // _6 = move _8
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: *mut libc::c_int = &mut x;
+        let mut z: *mut *mut libc::c_int = &mut y;
+        let mut w: *mut libc::c_int = 0 as *mut libc::c_int;
+        let mut v: *mut libc::c_int = w;
+        w = *z;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(8));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![2]);
+            assert_eq!(sol(&res, 5), vec![2]);
+            assert_eq!(sol(&res, 6), vec![1]);
+            assert_eq!(sol(&res, 7), vec![1]);
+            assert_eq!(sol(&res, 8), vec![1]);
+        },
+    );
+}
+
+#[test]
+fn test_deref_eq() {
+    // _1 = const 0_i32
+    // _2 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _4 = &mut _2
+    // _3 = &raw mut (*_4)
+    // _6 = &mut _1
+    // _5 = &raw mut (*_6)
+    // (*_3) = move _5
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: *mut libc::c_int = 0 as *mut libc::c_int;
+        let mut z: *mut *mut libc::c_int = &mut y;
+        *z = &mut x;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(6));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![2]);
+            assert_eq!(sol(&res, 4), vec![2]);
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![1]);
+        },
+    );
+}
+
+#[test]
+fn test_deref_eq_subset() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _4 = &mut _1
+    // _3 = &raw mut (*_4)
+    // _6 = &mut _3
+    // _5 = &raw mut (*_6)
+    // _8 = &mut _2
+    // _7 = &raw mut (*_8)
+    // (*_5) = move _7
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        let mut z: *mut libc::c_int = &mut x;
+        let mut w: *mut *mut libc::c_int = &mut z;
+        *w = &mut y;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(8));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![1, 2]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![3]);
+            assert_eq!(sol(&res, 6), vec![3]);
+            assert_eq!(sol(&res, 7), vec![2]);
+            assert_eq!(sol(&res, 8), vec![2]);
+        },
+    );
+}
+
+#[test]
+fn test_deref_eq_propagate() {
+    // _1 = const 0_i32
+    // _2 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _4 = &mut _2
+    // _3 = &raw mut (*_4)
+    // _5 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _6 = _2
+    // _5 = move _6
+    // _8 = &mut _1
+    // _7 = &raw mut (*_8)
+    // (*_3) = move _7
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: *mut libc::c_int = 0 as *mut libc::c_int;
+        let mut z: *mut *mut libc::c_int = &mut y;
+        let mut w: *mut libc::c_int = 0 as *mut libc::c_int;
+        w = y;
+        *z = &mut x;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(8));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![2]);
+            assert_eq!(sol(&res, 4), vec![2]);
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![1]);
+            assert_eq!(sol(&res, 7), vec![1]);
+            assert_eq!(sol(&res, 8), vec![1]);
+        },
+    );
+}
+
+#[test]
+fn test_array_aggregate() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _5 = &mut _1
+    // _4 = &raw mut (*_5)
+    // _7 = &mut _2
+    // _6 = &raw mut (*_7)
+    // _3 = [move _4, move _6]
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        let mut p: [*mut libc::c_int; 2] = [&mut x, &mut y];
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(7));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![1, 2]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![2]);
+            assert_eq!(sol(&res, 7), vec![2]);
+        },
+    );
+}
+
+#[test]
+fn test_array_eq_ref() {
+    // _2 = const 0_usize as *mut i32 (PointerWithExposedProvenance)
+    // _1 = [move _2; 2]
+    // _3 = const 0_i32
+    // _4 = const 0_i32
+    // _6 = &mut _3
+    // _5 = &raw mut (*_6)
+    // _7 = const 0_i32 as usize (IntToInt)
+    // _8 = Lt(copy _7, const 2_usize)
+    // _1[_7] = move _5
+    // _10 = &mut _4
+    // _9 = &raw mut (*_10)
+    // _11 = const 1_i32 as usize (IntToInt)
+    // _12 = Lt(copy _11, const 2_usize)
+    // _1[_11] = move _9
+    analyze_fn(
+        "
+        let mut p: [*mut libc::c_int; 2] = [0 as *mut libc::c_int; 2];
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        p[0 as libc::c_int as usize] = &mut x;
+        p[1 as libc::c_int as usize] = &mut y;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(12));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), vec![3, 4]);
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), e());
+            assert_eq!(sol(&res, 4), e());
+            assert_eq!(sol(&res, 5), vec![3]);
+            assert_eq!(sol(&res, 6), vec![3]);
+            assert_eq!(sol(&res, 7), e());
+            assert_eq!(sol(&res, 8), e());
+            assert_eq!(sol(&res, 9), vec![4]);
+            assert_eq!(sol(&res, 10), vec![4]);
+            assert_eq!(sol(&res, 11), e());
+            assert_eq!(sol(&res, 12), e());
+        },
+    );
+}
+
+#[test]
+fn test_struct_aggregate() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _5 = &mut _1
+    // _4 = &raw mut (*_5)
+    // _7 = &mut _2
+    // _6 = &raw mut (*_7)
+    // _3 = s { x: move _4, y: move _6, z: const 0_i32 }
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+            pub z: libc::c_int,
+        }
+        ",
+        "",
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        let mut z: s = {
+            let mut init = s {
+                x: &mut x,
+                y: &mut y,
+                z: 0 as libc::c_int,
+            };
+            init
+        };
+        ",
+        |res, _| {
+            assert_eq!(res.ends, vec![0, 1, 2, 5, 4, 5, 6, 7, 8, 9]);
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![2]);
+            assert_eq!(sol(&res, 5), e());
+            assert_eq!(sol(&res, 6), vec![1]);
+            assert_eq!(sol(&res, 7), vec![1]);
+            assert_eq!(sol(&res, 8), vec![2]);
+            assert_eq!(sol(&res, 9), vec![2]);
+        },
+    );
+}
+
+#[test]
+fn test_struct_eq_ref() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _3 = const 0_i32
+    // _4 = const 0_i32
+    // _6 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _7 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _5 = t { x: move _6, y: move _7 }
+    // _9 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _10 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _8 = t { x: move _9, y: move _10 }
+    // _13 = &mut _1
+    // _12 = &raw mut (*_13)
+    // _15 = &mut _2
+    // _14 = &raw mut (*_15)
+    // _11 = t { x: move _12, y: move _14 }
+    // _18 = &mut _3
+    // _17 = &raw mut (*_18)
+    // _20 = &mut _4
+    // _19 = &raw mut (*_20)
+    // _16 = t { x: move _17, y: move _19 }
+    // _5 = _11
+    // _8 = _16
+    // _23 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _24 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _22 = t { x: move _23, y: move _24 }
+    // _26 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _27 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _25 = t { x: move _26, y: move _27 }
+    // _21 = s { x: move _22, y: move _25 }
+    // _28 = s { x: _11, y: _16 }
+    // _21 = _28
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct t {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: t,
+            pub y: t,
+        }
+        ",
+        "",
+        "
+        let mut x0: libc::c_int = 0 as libc::c_int;
+        let mut x1: libc::c_int = 0 as libc::c_int;
+        let mut x2: libc::c_int = 0 as libc::c_int;
+        let mut x3: libc::c_int = 0 as libc::c_int;
+        let mut t0: t = t {
+            x: 0 as *mut libc::c_int,
+            y: 0 as *mut libc::c_int,
+        };
+        let mut t1: t = t {
+            x: 0 as *mut libc::c_int,
+            y: 0 as *mut libc::c_int,
+        };
+        let mut t2: t = {
+            let mut init = t { x: &mut x0, y: &mut x1 };
+            init
+        };
+        let mut t3: t = {
+            let mut init = t { x: &mut x2, y: &mut x3 };
+            init
+        };
+        t0 = t2;
+        t1 = t3;
+        let mut s0: s = s {
+            x: t {
+                x: 0 as *mut libc::c_int,
+                y: 0 as *mut libc::c_int,
+            },
+            y: t {
+                x: 0 as *mut libc::c_int,
+                y: 0 as *mut libc::c_int,
+            },
+        };
+        let mut s1: s = {
+            let mut init = s { x: t2, y: t3 };
+            init
+        };
+        s0 = s1;
+        ",
+        |res, _| {
+            assert_eq!(
+                res.ends,
+                vec![
+                    0, 1, 2, 3, 4, 6, 6, 7, 8, 10, 10, 11, 12, 14, 14, 15, 16, 17, 18, 20, 20, 21,
+                    22, 23, 24, 28, 26, 28, 28, 30, 30, 31, 32, 34, 34, 35, 36, 40, 38, 40, 40
+                ]
+            );
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), e());
+            assert_eq!(sol(&res, 4), e());
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![2]);
+            assert_eq!(sol(&res, 7), e());
+            assert_eq!(sol(&res, 8), e());
+            assert_eq!(sol(&res, 9), vec![3]);
+            assert_eq!(sol(&res, 10), vec![4]);
+            assert_eq!(sol(&res, 11), e());
+            assert_eq!(sol(&res, 12), e());
+            assert_eq!(sol(&res, 13), vec![1]);
+            assert_eq!(sol(&res, 14), vec![2]);
+            assert_eq!(sol(&res, 15), vec![1]);
+            assert_eq!(sol(&res, 16), vec![1]);
+            assert_eq!(sol(&res, 17), vec![2]);
+            assert_eq!(sol(&res, 18), vec![2]);
+            assert_eq!(sol(&res, 19), vec![3]);
+            assert_eq!(sol(&res, 20), vec![4]);
+            assert_eq!(sol(&res, 21), vec![3]);
+            assert_eq!(sol(&res, 22), vec![3]);
+            assert_eq!(sol(&res, 23), vec![4]);
+            assert_eq!(sol(&res, 24), vec![4]);
+            assert_eq!(sol(&res, 25), vec![1]);
+            assert_eq!(sol(&res, 26), vec![2]);
+            assert_eq!(sol(&res, 27), vec![3]);
+            assert_eq!(sol(&res, 28), vec![4]);
+            assert_eq!(sol(&res, 29), e());
+            assert_eq!(sol(&res, 30), e());
+            assert_eq!(sol(&res, 31), e());
+            assert_eq!(sol(&res, 32), e());
+            assert_eq!(sol(&res, 33), e());
+            assert_eq!(sol(&res, 34), e());
+            assert_eq!(sol(&res, 35), e());
+            assert_eq!(sol(&res, 36), e());
+            assert_eq!(sol(&res, 37), vec![1]);
+            assert_eq!(sol(&res, 38), vec![2]);
+            assert_eq!(sol(&res, 39), vec![3]);
+            assert_eq!(sol(&res, 40), vec![4]);
+        },
+    );
+}
+
+#[test]
+fn test_struct_deref_eq() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _3 = const 0_i32
+    // _4 = const 0_i32
+    // _7 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _8 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _6 = t { x: move _7, y: move _8 }
+    // _10 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _11 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _9 = t { x: move _10, y: move _11 }
+    // _5 = s { x: move _6, y: move _9 }
+    // _13 = &mut _5
+    // _12 = &raw mut (*_13)
+    // _15 = &mut _1
+    // _14 = &raw mut (*_15)
+    // (((*_12).0: t).0: *mut i32) = move _14
+    // _17 = &mut _2
+    // _16 = &raw mut (*_17)
+    // (((*_12).0: t).1: *mut i32) = move _16
+    // _19 = &mut _3
+    // _18 = &raw mut (*_19)
+    // (((*_12).1: t).0: *mut i32) = move _18
+    // _21 = &mut _4
+    // _20 = &raw mut (*_21)
+    // (((*_12).1: t).1: *mut i32) = move _20
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct t {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: t,
+            pub y: t,
+        }
+        ",
+        "",
+        "
+        let mut x0: libc::c_int = 0 as libc::c_int;
+        let mut x1: libc::c_int = 0 as libc::c_int;
+        let mut x2: libc::c_int = 0 as libc::c_int;
+        let mut x3: libc::c_int = 0 as libc::c_int;
+        let mut z: s = s {
+            x: t {
+                x: 0 as *mut libc::c_int,
+                y: 0 as *mut libc::c_int,
+            },
+            y: t {
+                x: 0 as *mut libc::c_int,
+                y: 0 as *mut libc::c_int,
+            },
+        };
+        let mut w: *mut s = &mut z;
+        (*w).x.x = &mut x0;
+        (*w).x.y = &mut x1;
+        (*w).y.x = &mut x2;
+        (*w).y.y = &mut x3;
+        ",
+        |res, _| {
+            assert_eq!(
+                res.ends,
+                vec![
+                    0, 1, 2, 3, 4, 8, 6, 8, 8, 10, 10, 11, 12, 14, 14, 15, 16, 17, 18, 19, 20, 21,
+                    22, 23, 24, 25, 26
+                ]
+            );
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), e());
+            assert_eq!(sol(&res, 4), e());
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![2]);
+            assert_eq!(sol(&res, 7), vec![3]);
+            assert_eq!(sol(&res, 8), vec![4]);
+            assert_eq!(sol(&res, 9), e());
+            assert_eq!(sol(&res, 10), e());
+            assert_eq!(sol(&res, 11), e());
+            assert_eq!(sol(&res, 12), e());
+            assert_eq!(sol(&res, 13), e());
+            assert_eq!(sol(&res, 14), e());
+            assert_eq!(sol(&res, 15), e());
+            assert_eq!(sol(&res, 16), e());
+            assert_eq!(sol(&res, 17), vec![5]);
+            assert_eq!(sol(&res, 18), vec![5]);
+            assert_eq!(sol(&res, 19), vec![1]);
+            assert_eq!(sol(&res, 20), vec![1]);
+            assert_eq!(sol(&res, 21), vec![2]);
+            assert_eq!(sol(&res, 22), vec![2]);
+            assert_eq!(sol(&res, 23), vec![3]);
+            assert_eq!(sol(&res, 24), vec![3]);
+            assert_eq!(sol(&res, 25), vec![4]);
+            assert_eq!(sol(&res, 26), vec![4]);
+        },
+    );
+}
+
+#[test]
+fn test_struct_eq_deref() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _3 = const 0_i32
+    // _4 = const 0_i32
+    // _9 = &mut _1
+    // _8 = &raw mut (*_9)
+    // _11 = &mut _2
+    // _10 = &raw mut (*_11)
+    // _7 = t { x: move _8, y: move _10 }
+    // _14 = &mut _3
+    // _13 = &raw mut (*_14)
+    // _16 = &mut _4
+    // _15 = &raw mut (*_16)
+    // _12 = t { x: move _13, y: move _15 }
+    // _6 = s { x: _7, y: _12 }
+    // _5 = _6
+    // _18 = &mut _5
+    // _17 = &raw mut (*_18)
+    // _19 = (((*_17).0: t).0: *mut i32)
+    // _20 = (((*_17).0: t).1: *mut i32)
+    // _21 = (((*_17).1: t).0: *mut i32)
+    // _22 = (((*_17).1: t).1: *mut i32)
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct t {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: t,
+            pub y: t,
+        }
+        ",
+        "",
+        "
+        let mut x0: libc::c_int = 0 as libc::c_int;
+        let mut x1: libc::c_int = 0 as libc::c_int;
+        let mut x2: libc::c_int = 0 as libc::c_int;
+        let mut x3: libc::c_int = 0 as libc::c_int;
+        let mut z: s = {
+            let mut init = s {
+                x: {
+                    let mut init = t { x: &mut x0, y: &mut x1 };
+                    init
+                },
+                y: {
+                    let mut init = t { x: &mut x2, y: &mut x3 };
+                    init
+                },
+            };
+            init
+        };
+        let mut w: *mut s = &mut z;
+        let mut y0: *mut libc::c_int = (*w).x.x;
+        let mut y1: *mut libc::c_int = (*w).x.y;
+        let mut y2: *mut libc::c_int = (*w).y.x;
+        let mut y3: *mut libc::c_int = (*w).y.y;
+        ",
+        |res, _| {
+            assert_eq!(
+                res.ends,
+                vec![
+                    0, 1, 2, 3, 4, 8, 6, 8, 8, 12, 10, 12, 12, 14, 14, 15, 16, 17, 18, 20, 20, 21,
+                    22, 23, 24, 25, 26, 27, 28, 29, 30
+                ]
+            );
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), e());
+            assert_eq!(sol(&res, 4), e());
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![2]);
+            assert_eq!(sol(&res, 7), vec![3]);
+            assert_eq!(sol(&res, 8), vec![4]);
+            assert_eq!(sol(&res, 9), vec![1]);
+            assert_eq!(sol(&res, 10), vec![2]);
+            assert_eq!(sol(&res, 11), vec![3]);
+            assert_eq!(sol(&res, 12), vec![4]);
+            assert_eq!(sol(&res, 13), vec![1]);
+            assert_eq!(sol(&res, 14), vec![2]);
+            assert_eq!(sol(&res, 15), vec![1]);
+            assert_eq!(sol(&res, 16), vec![1]);
+            assert_eq!(sol(&res, 17), vec![2]);
+            assert_eq!(sol(&res, 18), vec![2]);
+            assert_eq!(sol(&res, 19), vec![3]);
+            assert_eq!(sol(&res, 20), vec![4]);
+            assert_eq!(sol(&res, 21), vec![3]);
+            assert_eq!(sol(&res, 22), vec![3]);
+            assert_eq!(sol(&res, 23), vec![4]);
+            assert_eq!(sol(&res, 24), vec![4]);
+            assert_eq!(sol(&res, 25), vec![5]);
+            assert_eq!(sol(&res, 26), vec![5]);
+            assert_eq!(sol(&res, 27), vec![1]);
+            assert_eq!(sol(&res, 28), vec![2]);
+            assert_eq!(sol(&res, 29), vec![3]);
+            assert_eq!(sol(&res, 30), vec![4]);
+        },
+    );
+}
+
+#[test]
+fn test_struct_field_ref() {
+    // _3 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _4 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _2 = t { x: move _3, y: move _4 }
+    // _6 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _7 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _5 = t { x: move _6, y: move _7 }
+    // _1 = s { x: move _2, y: move _5 }
+    // _9 = &mut ((_1.0: t).0: *mut i32)
+    // _8 = &raw mut (*_9)
+    // _11 = &mut ((_1.0: t).1: *mut i32)
+    // _10 = &raw mut (*_11)
+    // _13 = &mut ((_1.1: t).0: *mut i32)
+    // _12 = &raw mut (*_13)
+    // _15 = &mut ((_1.1: t).1: *mut i32)
+    // _14 = &raw mut (*_15)
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct t {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: t,
+            pub y: t,
+        }
+        ",
+        "",
+        "
+        let mut s: s = s {
+            x: t {
+                x: 0 as *mut libc::c_int,
+                y: 0 as *mut libc::c_int,
+            },
+            y: t {
+                x: 0 as *mut libc::c_int,
+                y: 0 as *mut libc::c_int,
+            },
+        };
+        let mut x0: *mut *mut libc::c_int = &mut s.x.x;
+        let mut x1: *mut *mut libc::c_int = &mut s.x.y;
+        let mut x2: *mut *mut libc::c_int = &mut s.y.x;
+        let mut x3: *mut *mut libc::c_int = &mut s.y.y;
+        ",
+        |res, _| {
+            assert_eq!(
+                res.ends,
+                vec![0, 4, 2, 4, 4, 6, 6, 7, 8, 10, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+            );
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), e());
+            assert_eq!(sol(&res, 4), e());
+            assert_eq!(sol(&res, 5), e());
+            assert_eq!(sol(&res, 6), e());
+            assert_eq!(sol(&res, 7), e());
+            assert_eq!(sol(&res, 8), e());
+            assert_eq!(sol(&res, 9), e());
+            assert_eq!(sol(&res, 10), e());
+            assert_eq!(sol(&res, 11), e());
+            assert_eq!(sol(&res, 12), e());
+            assert_eq!(sol(&res, 13), vec![1]);
+            assert_eq!(sol(&res, 14), vec![1]);
+            assert_eq!(sol(&res, 15), vec![2]);
+            assert_eq!(sol(&res, 16), vec![2]);
+            assert_eq!(sol(&res, 17), vec![3]);
+            assert_eq!(sol(&res, 18), vec![3]);
+            assert_eq!(sol(&res, 19), vec![4]);
+            assert_eq!(sol(&res, 20), vec![4]);
+        },
+    );
+}
+
+#[test]
+fn test_struct_field_deref_ref() {
+    // _3 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _4 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _2 = t { x: move _3, y: move _4 }
+    // _6 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _7 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _5 = t { x: move _6, y: move _7 }
+    // _1 = s { x: move _2, y: move _5 }
+    // _9 = &mut (_1.0: t)
+    // _8 = &raw mut (*_9)
+    // _11 = &mut (_1.1: t)
+    // _10 = &raw mut (*_11)
+    // _13 = &mut ((*_8).0: *mut i32)
+    // _12 = &raw mut (*_13)
+    // _15 = &mut ((*_8).1: *mut i32)
+    // _14 = &raw mut (*_15)
+    // _17 = &mut ((*_10).0: *mut i32)
+    // _16 = &raw mut (*_17)
+    // _19 = &mut ((*_10).1: *mut i32)
+    // _18 = &raw mut (*_19)
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct t {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: t,
+            pub y: t,
+        }
+        ",
+        "",
+        "
+        let mut s: s = s {
+            x: t {
+                x: 0 as *mut libc::c_int,
+                y: 0 as *mut libc::c_int,
+            },
+            y: t {
+                x: 0 as *mut libc::c_int,
+                y: 0 as *mut libc::c_int,
+            },
+        };
+        let mut t0: *mut t = &mut s.x;
+        let mut t1: *mut t = &mut s.y;
+        let mut x0: *mut *mut libc::c_int = &mut (*t0).x;
+        let mut x1: *mut *mut libc::c_int = &mut (*t0).y;
+        let mut x2: *mut *mut libc::c_int = &mut (*t1).x;
+        let mut x3: *mut *mut libc::c_int = &mut (*t1).y;
+        ",
+        |res, _| {
+            assert_eq!(
+                res.ends,
+                vec![
+                    0, 4, 2, 4, 4, 6, 6, 7, 8, 10, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+                    22, 23, 24
+                ]
+            );
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), e());
+            assert_eq!(sol(&res, 4), e());
+            assert_eq!(sol(&res, 5), e());
+            assert_eq!(sol(&res, 6), e());
+            assert_eq!(sol(&res, 7), e());
+            assert_eq!(sol(&res, 8), e());
+            assert_eq!(sol(&res, 9), e());
+            assert_eq!(sol(&res, 10), e());
+            assert_eq!(sol(&res, 11), e());
+            assert_eq!(sol(&res, 12), e());
+            assert_eq!(sol(&res, 13), vec![1]);
+            assert_eq!(sol(&res, 14), vec![1]);
+            assert_eq!(sol(&res, 15), vec![3]);
+            assert_eq!(sol(&res, 16), vec![3]);
+            assert_eq!(sol(&res, 17), vec![1]);
+            assert_eq!(sol(&res, 18), vec![1]);
+            assert_eq!(sol(&res, 19), vec![2]);
+            assert_eq!(sol(&res, 20), vec![2]);
+            assert_eq!(sol(&res, 21), vec![3]);
+            assert_eq!(sol(&res, 22), vec![3]);
+            assert_eq!(sol(&res, 23), vec![4]);
+            assert_eq!(sol(&res, 24), vec![4]);
+        },
+    );
+}
+
+#[test]
+fn test_struct_deref_eq_ends() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _3 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _4 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _7 = &mut _3
+    // _6 = &raw mut (*_7)
+    // _5 = move _6 as *mut s (PtrToPtr)
+    // _9 = &mut _1
+    // _8 = &raw mut (*_9)
+    // ((*_5).0: *mut i32) = move _8
+    // _11 = &mut _2
+    // _10 = &raw mut (*_11)
+    // ((*_5).1: *mut i32) = move _10
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        ",
+        "",
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        let mut z: *mut libc::c_int = 0 as *mut libc::c_int;
+        let mut w: *mut libc::c_int = 0 as *mut libc::c_int;
+        let mut v: *mut s = &mut z as *mut *mut libc::c_int as *mut s;
+        (*v).x = &mut x;
+        (*v).y = &mut y;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(11));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), e());
+            assert_eq!(sol(&res, 5), vec![3]);
+            assert_eq!(sol(&res, 6), vec![3]);
+            assert_eq!(sol(&res, 7), vec![3]);
+            assert_eq!(sol(&res, 8), vec![1]);
+            assert_eq!(sol(&res, 9), vec![1]);
+            assert_eq!(sol(&res, 10), vec![2]);
+            assert_eq!(sol(&res, 11), vec![2]);
+        },
+    );
+}
+
+#[test]
+fn test_struct_eq_deref_ends() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _4 = &mut _1
+    // _3 = &raw mut (*_4)
+    // _6 = &mut _2
+    // _5 = &raw mut (*_6)
+    // _9 = &mut _3
+    // _8 = &raw mut (*_9)
+    // _7 = move _8 as *mut s (PtrToPtr)
+    // _10 = ((*_7).0: *mut i32)
+    // _11 = ((*_7).1: *mut i32)
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        ",
+        "",
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        let mut z: *mut libc::c_int = &mut x;
+        let mut w: *mut libc::c_int = &mut y;
+        let mut v: *mut s = &mut z as *mut *mut libc::c_int as *mut s;
+        let mut u: *mut libc::c_int = (*v).x;
+        let mut t: *mut libc::c_int = (*v).y;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(11));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![2]);
+            assert_eq!(sol(&res, 6), vec![2]);
+            assert_eq!(sol(&res, 7), vec![3]);
+            assert_eq!(sol(&res, 8), vec![3]);
+            assert_eq!(sol(&res, 9), vec![3]);
+            assert_eq!(sol(&res, 10), vec![1]);
+            assert_eq!(sol(&res, 11), e());
+        },
+    );
+}
+
+#[test]
+fn test_struct_ref_deref_ends() {
+    // _1 = const 0_i32
+    // _4 = &mut _1
+    // _3 = &raw mut (*_4)
+    // _2 = move _3 as *mut s (PtrToPtr)
+    // _6 = &mut ((*_2).0: *mut i32)
+    // _5 = &raw mut (*_6)
+    // _8 = &mut ((*_2).1: *mut i32)
+    // _7 = &raw mut (*_8)
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        ",
+        "",
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: *mut s = &mut x as *mut libc::c_int as *mut s;
+        let mut z: *mut *mut libc::c_int = &mut (*y).x;
+        let mut w: *mut *mut libc::c_int = &mut (*y).y;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(8));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![1]);
+            assert_eq!(sol(&res, 7), e());
+            assert_eq!(sol(&res, 8), e());
+        },
+    );
+}
+
+#[test]
+fn test_union_aggregate() {
+    // _1 = const 0_i32
+    // _4 = &mut _1
+    // _3 = &raw mut (*_4)
+    // _2 = u { x: move _3 }
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub union u {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        ",
+        "",
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: u = u { y: &mut x };
+        ",
+        |res, _| {
+            assert_eq!(res.ends, vec![0, 1, 3, 3, 4, 5]);
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![1]);
+        },
+    );
+}
+
+#[test]
+fn test_copy_for_deref() {
+    // _1 = const 0_i32
+    // _2 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _4 = &mut _2
+    // _3 = &raw mut (*_4)
+    // _6 = &mut _3
+    // _5 = &raw mut (*_6)
+    // _8 = &mut _1
+    // _7 = &raw mut (*_8)
+    // _9 = deref_copy (*_5)
+    // (*_9) = move _7
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: libc::c_int,
+        }
+        ",
+        "",
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: *mut libc::c_int = 0 as *mut libc::c_int;
+        let mut z: *mut *mut libc::c_int = &mut y;
+        let mut w: *mut *mut *mut libc::c_int = &mut z;
+        **w = &mut x;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(9));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![2]);
+            assert_eq!(sol(&res, 4), vec![2]);
+            assert_eq!(sol(&res, 5), vec![3]);
+            assert_eq!(sol(&res, 6), vec![3]);
+            assert_eq!(sol(&res, 7), vec![1]);
+            assert_eq!(sol(&res, 8), vec![1]);
+            assert_eq!(sol(&res, 9), vec![2]);
+        },
+    );
+}
+
+#[test]
+fn test_static() {
+    // _3 = const {alloc1: *mut i32}
+    // _2 = &mut (*_3)
+    // _1 = &raw mut (*_2)
+    analyze_fn_with(
+        "
+        pub static mut x: libc::c_int = 0;
+        ",
+        "",
+        "
+        let mut y: *mut libc::c_int = &mut x;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(4));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![0]);
+            assert_eq!(sol(&res, 3), vec![0]);
+            assert_eq!(sol(&res, 4), vec![0]);
+        },
+    );
+}
+
+#[test]
+fn test_static_struct_field_eq() {
+    // _2 = const 0_usize as *const i32 (PointerFromExposedAddress)
+    // _1 = move _2 as *mut i32 (PtrToPtr)
+    // _4 = const 0_usize as *const i32 (PointerFromExposedAddress)
+    // _3 = move _4 as *mut i32 (PtrToPtr)
+    // _0 = s { x: move _1, y: move _3 }
+    //
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _4 = &mut _1
+    // _3 = &raw mut (*_4)
+    // _5 = const {alloc1: *mut s}
+    // ((*_5).0: *mut i32) = move _3
+    // _7 = &mut _2
+    // _6 = &raw mut (*_7)
+    // _8 = const {alloc1: *mut s}
+    // ((*_8).1: *mut i32) = move _6
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        pub static mut z: s = s {
+            x: 0 as *const libc::c_int as *mut libc::c_int,
+            y: 0 as *const libc::c_int as *mut libc::c_int,
+        };
+        ",
+        "",
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        z.x = &mut x;
+        z.y = &mut y;
+        ",
+        |res, _| {
+            assert_eq!(
+                res.ends,
+                vec![1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+            );
+            assert_eq!(sol(&res, 0), vec![7]);
+            assert_eq!(sol(&res, 1), vec![8]);
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), e());
+            assert_eq!(sol(&res, 4), e());
+            assert_eq!(sol(&res, 5), e());
+            assert_eq!(sol(&res, 6), e());
+            assert_eq!(sol(&res, 7), e());
+            assert_eq!(sol(&res, 8), e());
+            assert_eq!(sol(&res, 9), vec![7]);
+            assert_eq!(sol(&res, 10), vec![7]);
+            assert_eq!(sol(&res, 11), vec![0]);
+            assert_eq!(sol(&res, 12), vec![8]);
+            assert_eq!(sol(&res, 13), vec![8]);
+            assert_eq!(sol(&res, 14), vec![0]);
+        },
+    );
+}
+
+#[test]
+fn test_static_struct_field_ref() {
+    // _0 = s { x: const 0_i32, y: const 0_i32 }
+    //
+    // _3 = const {alloc1: *mut s}
+    // _2 = &mut ((*_3).0: i32)
+    // _1 = &raw mut (*_2)
+    // _6 = const {alloc1: *mut s}
+    // _5 = &mut ((*_6).1: i32)
+    // _4 = &raw mut (*_5)
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: libc::c_int,
+            pub y: libc::c_int,
+        }
+        pub static mut s: s = s { x: 0, y: 0 };
+        ",
+        "",
+        "
+        let mut x: *mut libc::c_int = &mut s.x;
+        let mut y: *mut libc::c_int = &mut s.y;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, vec![1, 1, 2, 3, 4, 5, 6, 7, 8]);
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![0]);
+            assert_eq!(sol(&res, 4), vec![0]);
+            assert_eq!(sol(&res, 5), vec![0]);
+            assert_eq!(sol(&res, 6), vec![1]);
+            assert_eq!(sol(&res, 7), vec![1]);
+            assert_eq!(sol(&res, 8), vec![0]);
+        },
+    );
+}
+
+#[test]
+fn test_static_ref() {
+    // _3 = const {alloc1: *mut i32}
+    // _2 = &(*_3)
+    // _1 = &raw const (*_2)
+    // _0 = move _1 as *mut i32 (PtrToPtr)
+    analyze_fn_with(
+        "
+        pub static mut x: libc::c_int = 0 as libc::c_int;
+        pub static mut y: *mut libc::c_int = unsafe {
+            &x as *const libc::c_int as *mut libc::c_int
+        };
+        ",
+        "",
+        "
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(5));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), vec![0]);
+            assert_eq!(sol(&res, 2), vec![0]);
+            assert_eq!(sol(&res, 3), vec![0]);
+            assert_eq!(sol(&res, 4), vec![0]);
+            assert_eq!(sol(&res, 5), e());
+        },
+    );
+}
+
+#[test]
+fn test_static_struct_ref() {
+    // _5 = const {alloc1: *mut i32}
+    // _4 = &(*_5)
+    // _3 = &raw const (*_4)
+    // _2 = move _3 as *mut i32 (PtrToPtr)
+    // _9 = const {alloc2: *mut i32}
+    // _8 = &(*_9)
+    // _7 = &raw const (*_8)
+    // _6 = move _7 as *mut i32 (PtrToPtr)
+    // _1 = s { x: move _2, y: move _6 }
+    // _0 = _1
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        pub static mut x: libc::c_int = 0 as libc::c_int;
+        pub static mut y: libc::c_int = 0 as libc::c_int;
+        pub static mut z: s = unsafe {
+            {
+                let mut init = s {
+                    x: &x as *const libc::c_int as *mut libc::c_int,
+                    y: &y as *const libc::c_int as *mut libc::c_int,
+                };
+                init
+            }
+        };
+        ",
+        "",
+        "
+        ",
+        |res, _| {
+            assert_eq!(
+                res.ends,
+                vec![0, 1, 3, 3, 5, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+            );
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![0]);
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![0]);
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![0]);
+            assert_eq!(sol(&res, 7), vec![0]);
+            assert_eq!(sol(&res, 8), vec![0]);
+            assert_eq!(sol(&res, 9), vec![0]);
+            assert_eq!(sol(&res, 10), vec![1]);
+            assert_eq!(sol(&res, 11), vec![1]);
+            assert_eq!(sol(&res, 12), vec![1]);
+            assert_eq!(sol(&res, 13), vec![1]);
+            assert_eq!(sol(&res, 14), e());
+        },
+    );
+}
+
+#[test]
+fn test_cycle() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _4 = &mut _1
+    // _3 = &raw mut (*_4)
+    // _6 = &mut _2
+    // _5 = &raw mut (*_6)
+    // _7 = _5
+    // _3 = move _7
+    // _8 = _3
+    // _5 = move _8
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        let mut z: *mut libc::c_int = &mut x;
+        let mut w: *mut libc::c_int = &mut y;
+        z = w;
+        w = z;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(8));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![1, 2]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![1, 2]);
+            assert_eq!(sol(&res, 6), vec![2]);
+            assert_eq!(sol(&res, 7), vec![1, 2]);
+            assert_eq!(sol(&res, 8), vec![1, 2]);
+        },
+    );
+}
+
+#[test]
+fn test_cycle_propagate_eq() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _4 = &mut _1
+    // _3 = &raw mut (*_4)
+    // _5 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _7 = &mut _2
+    // _6 = &raw mut (*_7)
+    // _8 = _5
+    // _3 = move _8
+    // _9 = _3
+    // _5 = move _9
+    // _10 = _5
+    // _6 = move _10
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        let mut z: *mut libc::c_int = &mut x;
+        let mut w: *mut libc::c_int = 0 as *mut libc::c_int;
+        let mut v: *mut libc::c_int = &mut y;
+        z = w;
+        w = z;
+        v = w;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(10));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![1, 2]);
+            assert_eq!(sol(&res, 7), vec![2]);
+            assert_eq!(sol(&res, 8), vec![1]);
+            assert_eq!(sol(&res, 9), vec![1]);
+            assert_eq!(sol(&res, 10), vec![1]);
+        },
+    );
+}
+
+#[test]
+fn test_cycle_propagate_eq_deref() {
+    // _1 = const 0_i32
+    // _3 = &mut _1
+    // _2 = &raw mut (*_3)
+    // _5 = &mut _2
+    // _4 = &raw mut (*_5)
+    // _6 = const 0_usize as *mut *mut i32 (PointerFromExposedAddress)
+    // _7 = _4
+    // _6 = move _7
+    // _8 = _6
+    // _4 = move _8
+    // _9 = (*_4)
+    // _10 = (*_6)
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: *mut libc::c_int = &mut x;
+        let mut z: *mut *mut libc::c_int = &mut y;
+        let mut w: *mut *mut libc::c_int = 0 as *mut *mut libc::c_int;
+        w = z;
+        z = w;
+        let mut v: *mut libc::c_int = *z;
+        let mut u: *mut libc::c_int = *w;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(10));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![2]);
+            assert_eq!(sol(&res, 5), vec![2]);
+            assert_eq!(sol(&res, 6), vec![2]);
+            assert_eq!(sol(&res, 7), vec![2]);
+            assert_eq!(sol(&res, 8), vec![2]);
+            assert_eq!(sol(&res, 9), vec![1]);
+            assert_eq!(sol(&res, 10), vec![1]);
+        },
+    );
+}
+
+#[test]
+fn test_cycle_propagate_deref_eq() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _3 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _5 = &mut _3
+    // _4 = &raw mut (*_5)
+    // _6 = const 0_usize as *mut *mut i32 (PointerFromExposedAddress)
+    // _7 = _4
+    // _6 = move _7
+    // _8 = _6
+    // _4 = move _8
+    // _10 = &mut _1
+    // _9 = &raw mut (*_10)
+    // (*_4) = move _9
+    // _12 = &mut _2
+    // _11 = &raw mut (*_12)
+    // (*_6) = move _11
+    analyze_fn(
+        "
+        let mut x0: libc::c_int = 0 as libc::c_int;
+        let mut x1: libc::c_int = 0 as libc::c_int;
+        let mut y: *mut libc::c_int = 0 as *mut libc::c_int;
+        let mut z: *mut *mut libc::c_int = &mut y;
+        let mut w: *mut *mut libc::c_int = 0 as *mut *mut libc::c_int;
+        w = z;
+        z = w;
+        *z = &mut x0;
+        *w = &mut x1;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(12));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![1, 2]);
+            assert_eq!(sol(&res, 4), vec![3]);
+            assert_eq!(sol(&res, 5), vec![3]);
+            assert_eq!(sol(&res, 6), vec![3]);
+            assert_eq!(sol(&res, 7), vec![3]);
+            assert_eq!(sol(&res, 8), vec![3]);
+            assert_eq!(sol(&res, 9), vec![1]);
+            assert_eq!(sol(&res, 10), vec![1]);
+            assert_eq!(sol(&res, 11), vec![2]);
+            assert_eq!(sol(&res, 12), vec![2]);
+        },
+    );
+}
+
+#[test]
+fn test_cycle_propagate_ref_deref() {
+    // _1 = s { x: const 0_i32, y: const 0_i32 }
+    // _3 = &mut _1
+    // _2 = &raw mut (*_3)
+    // _4 = const 0_usize as *mut s (PointerFromExposedAddress)
+    // _5 = _4
+    // _2 = move _5
+    // _6 = _2
+    // _4 = move _6
+    // _8 = &mut ((*_2).1: i32)
+    // _7 = &raw mut (*_8)
+    // _10 = &mut ((*_4).1: i32)
+    // _9 = &raw mut (*_10)
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: libc::c_int,
+            pub y: libc::c_int,
+        }
+        ",
+        "",
+        "
+        let mut s: s = s { x: 0, y: 0 };
+        let mut x: *mut s = &mut s;
+        let mut y: *mut s = 0 as *mut s;
+        x = y;
+        y = x;
+        let mut z: *mut libc::c_int = &mut (*x).y;
+        let mut w: *mut libc::c_int = &mut (*y).y;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, vec![0, 2, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![1]);
+            assert_eq!(sol(&res, 7), vec![1]);
+            assert_eq!(sol(&res, 8), vec![2]);
+            assert_eq!(sol(&res, 9), vec![2]);
+            assert_eq!(sol(&res, 10), vec![2]);
+            assert_eq!(sol(&res, 11), vec![2]);
+        },
+    );
+}
+
+#[test]
+fn test_cycle_twice() {
+    // _1 = const 0_i32
+    // _3 = &mut _1
+    // _2 = &raw mut (*_3)
+    // _4 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _5 = const 0_usize as *mut i32 (PointerFromExposedAddress)
+    // _7 = &mut _4
+    // _6 = &raw mut (*_7)
+    // _8 = _4
+    // _2 = move _8
+    // _9 = _2
+    // _4 = move _9
+    // _10 = _5
+    // _4 = move _10
+    // _11 = (*_6)
+    // _5 = move _11
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: *mut libc::c_int = &mut x;
+        let mut z: *mut libc::c_int = 0 as *mut libc::c_int;
+        let mut w: *mut libc::c_int = 0 as *mut libc::c_int;
+        let mut v: *mut *mut libc::c_int = &mut z;
+        y = z;
+        z = y;
+        z = w;
+        w = *v;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(11));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![4]);
+            assert_eq!(sol(&res, 7), vec![4]);
+            assert_eq!(sol(&res, 8), vec![1]);
+            assert_eq!(sol(&res, 9), vec![1]);
+            assert_eq!(sol(&res, 10), vec![1]);
+            assert_eq!(sol(&res, 11), vec![1]);
+        },
+    );
+}
+
+#[test]
+fn test_call() {
+    // _2 = const 0_i32
+    // _4 = &mut _2
+    // _3 = &raw mut (*_4)
+    // _1 = move _3
+    // _0 = _1
+    //
+    // _1 = const 0_i32
+    // _3 = &mut _1
+    // _2 = &raw mut (*_3)
+    // _4 = g(_2)
+    // _5 = const 0_i32
+    // _7 = &mut _5
+    // _6 = &raw mut (*_7)
+    // _4 = move _6
+    analyze_fn_with(
+        "
+        pub unsafe extern \"C\" fn g(mut x: *mut libc::c_int) -> *mut libc::c_int {
+            let mut y: libc::c_int = 0 as libc::c_int;
+            x = &mut y;
+            return x;
+        }
+        ",
+        "",
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: *mut libc::c_int = &mut x;
+        let mut z: *mut libc::c_int = g(y);
+        let mut w: libc::c_int = 0 as libc::c_int;
+        z = &mut w;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(12));
+            assert_eq!(sol(&res, 0), vec![2, 6]);
+            assert_eq!(sol(&res, 1), vec![2, 6]);
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![2]);
+            assert_eq!(sol(&res, 4), vec![2]);
+            assert_eq!(sol(&res, 5), e()); // _0
+            assert_eq!(sol(&res, 6), e()); // _1
+            assert_eq!(sol(&res, 7), vec![6]);
+            assert_eq!(sol(&res, 8), vec![6]);
+            assert_eq!(sol(&res, 9), vec![2, 6, 10]);
+            assert_eq!(sol(&res, 10), e());
+            assert_eq!(sol(&res, 11), vec![10]);
+            assert_eq!(sol(&res, 12), vec![10]);
+        },
+    );
+}
+
+#[test]
+fn test_call_struct() {
+    // _4 = copy (_1.0: *mut i32)
+    // _5 = copy (_1.1: *mut i32)
+    // _0 = t { x: move _4, y: move _5, z: copy _3 }
+
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _3 = const 0_i32
+    // _6 = &mut _1
+    // _5 = &raw mut (*_6)
+    // _8 = &mut _2
+    // _7 = &raw mut (*_8)
+    // _4 = s { x: move _5, y: move _7 }
+    // _11 = &mut _3
+    // _10 = &raw mut (*_11)
+    // _9 = g(copy _4, const 0_i32, move _10) -> [return: bb1, unwind unreachable]
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct t {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+            pub z: *mut libc::c_int,
+        }
+        pub unsafe extern \"C\" fn g(mut x: s, mut y: libc::c_int, mut z: *mut libc::c_int) -> t {
+            let mut w: t = {
+                let mut init = t { x: x.x, y: x.y, z: z };
+                init
+            };
+            return w;
+        }
+        ",
+        "",
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        let mut z: libc::c_int = 0 as libc::c_int;
+        let mut w: s = {
+            let mut init = s { x: &mut x, y: &mut y };
+            init
+        };
+        let mut v: t = g(w, 0 as libc::c_int, &mut z);
+        ",
+        |res, _| {
+            assert_eq!(
+                res.ends,
+                vec![
+                    1, 1, 2, 3, 6, 5, 6, 7, 8, 9, 10, 11, 12, 14, 14, 15, 16, 17, 18, 21, 20, 21,
+                    22, 23
+                ]
+            );
+            assert_eq!(sol(&res, 0), vec![10]);
+            assert_eq!(sol(&res, 1), vec![11]);
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![12]);
+            assert_eq!(sol(&res, 4), vec![10]);
+            assert_eq!(sol(&res, 5), vec![11]);
+            assert_eq!(sol(&res, 6), vec![12]);
+            assert_eq!(sol(&res, 7), vec![10]);
+            assert_eq!(sol(&res, 8), vec![11]);
+            assert_eq!(sol(&res, 9), e());
+            assert_eq!(sol(&res, 10), e());
+            assert_eq!(sol(&res, 11), e());
+            assert_eq!(sol(&res, 12), e());
+            assert_eq!(sol(&res, 13), vec![10]);
+            assert_eq!(sol(&res, 14), vec![11]);
+            assert_eq!(sol(&res, 15), vec![10]);
+            assert_eq!(sol(&res, 16), vec![10]);
+            assert_eq!(sol(&res, 17), vec![11]);
+            assert_eq!(sol(&res, 18), vec![11]);
+            assert_eq!(sol(&res, 19), vec![10]);
+            assert_eq!(sol(&res, 20), vec![11]);
+            assert_eq!(sol(&res, 21), vec![12]);
+            assert_eq!(sol(&res, 22), vec![12]);
+            assert_eq!(sol(&res, 23), vec![12]);
+        },
+    );
+}
+
+#[test]
+fn test_call_fn_ptr() {
+    // _4 = copy (_1.0: *mut i32)
+    // _5 = copy (_1.1: *mut i32)
+    // _0 = t { x: move _4, y: move _5, z: copy _3 }
+
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _3 = const 0_i32
+    // _6 = &mut _1
+    // _5 = &raw mut (*_6)
+    // _8 = &mut _2
+    // _7 = &raw mut (*_8)
+    // _4 = s { x: move _5, y: move _7 }
+    // _10 = g as unsafe extern "C" fn(s, i32, *mut i32) -> t (PointerCoercion(ReifyFnPointer, AsCast))
+    // _9 = std::option::Option::<unsafe extern "C" fn(s, i32, *mut i32) -> t>::Some(move _10)
+    // _12 = std::option::Option::<unsafe extern "C" fn(s, i32, *mut i32) -> t>::unwrap(copy _9) -> [return: bb1, unwind terminate(abi)]
+    // _14 = &mut _3
+    // _13 = &raw mut (*_14)
+    // _11 = move _12(copy _4, const 0_i32, move _13) -> [return: bb2, unwind unreachable]
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct t {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+            pub z: *mut libc::c_int,
+        }
+        pub unsafe extern \"C\" fn g(mut x: s, mut y: libc::c_int, mut z: *mut libc::c_int) -> t {
+            let mut w: t = {
+                let mut init = t { x: x.x, y: x.y, z: z };
+                init
+            };
+            return w;
+        }
+        ",
+        "",
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        let mut z: libc::c_int = 0 as libc::c_int;
+        let mut w: s = {
+            let mut init = s { x: &mut x, y: &mut y };
+            init
+        };
+        let mut h: Option::<unsafe extern \"C\" fn(s, libc::c_int, *mut libc::c_int) -> t> = Some(
+            g as unsafe extern \"C\" fn(s, libc::c_int, *mut libc::c_int) -> t,
+        );
+        let mut v: t = h.unwrap()(w, 0 as libc::c_int, &mut z);
+        ",
+        |res, _| {
+            assert_eq!(
+                res.ends,
+                vec![
+                    6, 1, 2, 3, 6, 5, 6, 7, 8, 9, 10, 11, 12, 14, 14, 15, 16, 17, 18, 19, 20, 23,
+                    22, 23, 24, 25, 26
+                ]
+            );
+            assert_eq!(sol(&res, 0), vec![10]);
+            assert_eq!(sol(&res, 1), vec![11]);
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![12]);
+            assert_eq!(sol(&res, 4), vec![10]);
+            assert_eq!(sol(&res, 5), vec![11]);
+            assert_eq!(sol(&res, 6), vec![12]);
+            assert_eq!(sol(&res, 7), vec![10]);
+            assert_eq!(sol(&res, 8), vec![11]);
+            assert_eq!(sol(&res, 9), e());
+            assert_eq!(sol(&res, 10), e());
+            assert_eq!(sol(&res, 11), e());
+            assert_eq!(sol(&res, 12), e());
+            assert_eq!(sol(&res, 13), vec![10]);
+            assert_eq!(sol(&res, 14), vec![11]);
+            assert_eq!(sol(&res, 15), vec![10]);
+            assert_eq!(sol(&res, 16), vec![10]);
+            assert_eq!(sol(&res, 17), vec![11]);
+            assert_eq!(sol(&res, 18), vec![11]);
+            assert_eq!(sol(&res, 19), vec![0]);
+            assert_eq!(sol(&res, 20), vec![0]);
+            assert_eq!(sol(&res, 21), vec![10]);
+            assert_eq!(sol(&res, 22), vec![11]);
+            assert_eq!(sol(&res, 23), vec![12]);
+            assert_eq!(sol(&res, 24), vec![0]);
+            assert_eq!(sol(&res, 25), vec![12]);
+            assert_eq!(sol(&res, 26), vec![12]);
+        },
+    );
+}
+
+#[test]
+fn test_array_offset() {
+    // _1 = [const 0_i32; 2]
+    // _7 = &mut _1
+    // _6 = move _7 as &mut [i32] (PointerCoercion(Unsize, Implicit))
+    // _5 = core::slice::<impl [i32]>::as_mut_ptr(move _6) -> [return: bb1, unwind terminate(abi)]
+    // _8 = const 1_i32 as isize (IntToInt)
+    // _4 = std::ptr::mut_ptr::<impl *mut i32>::offset(move _5, move _8) -> [return: bb2, unwind terminate(abi)]
+    // _3 = &mut (*_4)
+    // _2 = &raw mut (*_3)
+    analyze_fn(
+        "
+        let mut x: [libc::c_int; 2] = [0; 2];
+        let mut y: *mut libc::c_int = &mut *x.as_mut_ptr().offset(1 as libc::c_int as isize)
+            as *mut libc::c_int;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(8));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![1]);
+            assert_eq!(sol(&res, 7), vec![1]);
+            assert_eq!(sol(&res, 8), e());
+        },
+    );
+}
+
+#[test]
+fn test_malloc() {
+    // _4 = std::mem::size_of::<i32>()
+    // _3 = move _4 as u64 (IntToInt)
+    // _2 = malloc(move _3)
+    // _1 = move _2 as *mut i32 (PtrToPtr)
+    analyze_fn(
+        "
+        let mut x: *mut libc::c_int = malloc(
+            ::std::mem::size_of::<libc::c_int>() as libc::c_ulong,
+        ) as *mut libc::c_int;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(5));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), vec![5]);
+            assert_eq!(sol(&res, 2), vec![5]);
+            assert_eq!(sol(&res, 3), e());
+            assert_eq!(sol(&res, 4), e());
+            assert_eq!(sol(&res, 5), e());
+        },
+    );
+}
+
+#[test]
+fn test_malloc_struct() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _3 = const 0_i32
+    // _4 = const 0_i32
+    // _8 = std::mem::size_of::<s>() -> [return: bb1, unwind continue]
+    // _7 = move _8 as u64 (IntToInt)
+    // _6 = malloc(move _7) -> [return: bb2, unwind continue]
+    // _5 = move _6 as *mut s (PtrToPtr)
+    // _10 = &mut _1
+    // _9 = &raw mut (*_10)
+    // ((*_5).0: *mut i32) = move _9
+    // _12 = &mut _2
+    // _11 = &raw mut (*_12)
+    // ((*_5).1: *mut i32) = move _11
+    // _14 = &mut _3
+    // _13 = &raw mut (*_14)
+    // ((*_5).2: *mut i32) = move _13
+    // _18 = std::mem::size_of::<r>() -> [return: bb3, unwind continue]
+    // _17 = move _18 as u64 (IntToInt)
+    // _16 = malloc(move _17) -> [return: bb4, unwind continue]
+    // _15 = move _16 as *mut r (PtrToPtr)
+    // _20 = &mut _1
+    // _19 = &raw mut (*_20)
+    // (((*_15).0: t).0: *mut i32) = move _19
+    // _22 = &mut _2
+    // _21 = &raw mut (*_22)
+    // (((*_15).0: t).1: *mut i32) = move _21
+    // _24 = &mut ((*_15).1: t)
+    // _23 = &raw mut (*_24)
+    // _26 = &mut _3
+    // _25 = &raw mut (*_26)
+    // ((*_23).0: *mut i32) = move _25
+    // _28 = &mut _4
+    // _27 = &raw mut (*_28)
+    // ((*_23).1: *mut i32) = move _27
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+            pub z: *mut libc::c_int,
+        }
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct t {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct r {
+            pub x: t,
+            pub y: t,
+        }
+        ",
+        "",
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        let mut z: libc::c_int = 0 as libc::c_int;
+        let mut w: libc::c_int = 0 as libc::c_int;
+        let mut s: *mut s = malloc(::std::mem::size_of::<s>() as libc::c_ulong) as *mut s;
+        (*s).x = &mut x;
+        (*s).y = &mut y;
+        (*s).z = &mut z;
+        let mut r: *mut r = malloc(::std::mem::size_of::<r>() as libc::c_ulong) as *mut r;
+        (*r).x.x = &mut x;
+        (*r).x.y = &mut y;
+        let mut t: *mut t = &mut (*r).y;
+        (*t).x = &mut z;
+        (*t).y = &mut w;
+        ",
+        |res, _| {
+            let mut v = v(28);
+            v.extend([32, 30, 32, 32, 36, 34, 36, 36]);
+            assert_eq!(res.ends, v);
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), e());
+            assert_eq!(sol(&res, 4), e());
+            assert_eq!(sol(&res, 5), vec![29]);
+            assert_eq!(sol(&res, 6), vec![29]);
+            assert_eq!(sol(&res, 7), e());
+            assert_eq!(sol(&res, 8), e());
+            assert_eq!(sol(&res, 9), vec![1]);
+            assert_eq!(sol(&res, 10), vec![1]);
+            assert_eq!(sol(&res, 11), vec![2]);
+            assert_eq!(sol(&res, 12), vec![2]);
+            assert_eq!(sol(&res, 13), vec![3]);
+            assert_eq!(sol(&res, 14), vec![3]);
+            assert_eq!(sol(&res, 15), vec![33]);
+            assert_eq!(sol(&res, 16), vec![33]);
+            assert_eq!(sol(&res, 17), e());
+            assert_eq!(sol(&res, 18), e());
+            assert_eq!(sol(&res, 19), vec![1]);
+            assert_eq!(sol(&res, 20), vec![1]);
+            assert_eq!(sol(&res, 21), vec![2]);
+            assert_eq!(sol(&res, 22), vec![2]);
+            assert_eq!(sol(&res, 23), vec![35]);
+            assert_eq!(sol(&res, 24), vec![35]);
+            assert_eq!(sol(&res, 25), vec![3]);
+            assert_eq!(sol(&res, 26), vec![3]);
+            assert_eq!(sol(&res, 27), vec![4]);
+            assert_eq!(sol(&res, 28), vec![4]);
+            assert_eq!(sol(&res, 29), vec![1]);
+            assert_eq!(sol(&res, 30), vec![2]);
+            assert_eq!(sol(&res, 31), vec![3]);
+            assert_eq!(sol(&res, 32), e());
+            assert_eq!(sol(&res, 33), vec![1]);
+            assert_eq!(sol(&res, 34), vec![2]);
+            assert_eq!(sol(&res, 35), vec![3]);
+            assert_eq!(sol(&res, 36), vec![4]);
+        },
+    );
+}
+
+#[test]
+fn test_custom_malloc() {
+    // _2 = _1 as u64 (IntToInt)
+    // _0 = malloc(move _2) -> [return: bb1, unwind continue]
+    //
+    // _5 = std::mem::size_of::<i32>() -> [return: bb1, unwind continue]
+    // _4 = move _5 as u64 (IntToInt)
+    // _3 = move _4 as i32 (IntToInt)
+    // _2 = g(move _3) -> [return: bb2, unwind continue]
+    // _1 = move _2 as *mut i32 (PtrToPtr)
+    // _10 = std::mem::size_of::<i32>() -> [return: bb3, unwind continue]
+    // _9 = move _10 as u64 (IntToInt)
+    // _8 = move _9 as i32 (IntToInt)
+    // _7 = g(move _8) -> [return: bb4, unwind continue]
+    // _6 = move _7 as *mut i32 (PtrToPtr)
+    analyze_fn_with(
+        "
+        pub unsafe extern \"C\" fn g(mut x: libc::c_int) -> *mut libc::c_void {
+            return malloc(x as libc::c_ulong);
+        }
+        ",
+        "",
+        "
+        let mut x: *mut libc::c_int = g(
+            ::std::mem::size_of::<libc::c_int>() as libc::c_ulong as libc::c_int,
+        ) as *mut libc::c_int;
+        let mut y: *mut libc::c_int = g(
+            ::std::mem::size_of::<libc::c_int>() as libc::c_ulong as libc::c_int,
+        ) as *mut libc::c_int;
+        ",
+        |res, _| {
+            assert_eq!(res.ends, v(16));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), vec![14]);
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), e());
+            assert_eq!(sol(&res, 4), vec![15]);
+            assert_eq!(sol(&res, 5), vec![15]);
+            assert_eq!(sol(&res, 6), e());
+            assert_eq!(sol(&res, 7), e());
+            assert_eq!(sol(&res, 8), e());
+            assert_eq!(sol(&res, 9), vec![16]);
+            assert_eq!(sol(&res, 10), vec![16]);
+            assert_eq!(sol(&res, 11), e());
+            assert_eq!(sol(&res, 12), e());
+            assert_eq!(sol(&res, 13), e());
+            assert_eq!(sol(&res, 14), e());
+            assert_eq!(sol(&res, 15), e());
+            assert_eq!(sol(&res, 16), e());
+        },
+    );
+}
+
+fn l(block: usize, statement_index: usize) -> Location {
+    Location {
+        block: BasicBlock::new(block),
+        statement_index,
+    }
+}
+
+fn wg(
+    writes: &HashMap<Location, HybridBitSet<usize>>,
+    block: usize,
+    statement_index: usize,
+) -> Vec<usize> {
+    writes
+        .get(&l(block, statement_index))
+        .unwrap()
+        .iter()
+        .collect()
+}
+
+#[test]
+fn test_writes_compound() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _3 = const 0_i32
+    // _7 = &mut _1
+    // _6 = &raw mut (*_7)
+    // _9 = &mut _2
+    // _8 = &raw mut (*_9)
+    // _5 = s { x: move _6, y: move _8 }
+    // _12 = &mut _3
+    // _11 = &raw mut (*_12)
+    // _13 = const 0_usize as *mut i32 (PointerWithExposedProvenance)
+    // _10 = [move _11, move _13]
+    // _4 = t { x: copy _5, y: move _10 }
+    // _1 = const 1_i32
+    // _2 = const 1_i32
+    // _3 = const 1_i32
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: *mut libc::c_int,
+            pub y: *mut libc::c_int,
+        }
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct t {
+            pub x: s,
+            pub y: [*mut libc::c_int; 2],
+        }
+        ",
+        "",
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        let mut z: libc::c_int = 0 as libc::c_int;
+        let mut w: t = {
+            let mut init = t {
+                x: {
+                    let mut init = s { x: &mut x, y: &mut y };
+                    init
+                },
+                y: [&mut z, 0 as *mut libc::c_int],
+            };
+            init
+        };
+        x = 1 as libc::c_int;
+        y = 1 as libc::c_int;
+        z = 1 as libc::c_int;
+        ",
+        |mut res, tcx| {
+            assert_eq!(
+                res.ends,
+                vec![0, 1, 2, 3, 6, 5, 6, 8, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+            );
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), e());
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![2]);
+            assert_eq!(sol(&res, 6), vec![3]);
+            assert_eq!(sol(&res, 7), vec![1]);
+            assert_eq!(sol(&res, 8), vec![2]);
+            assert_eq!(sol(&res, 9), vec![1]);
+            assert_eq!(sol(&res, 10), vec![1]);
+            assert_eq!(sol(&res, 11), vec![2]);
+            assert_eq!(sol(&res, 12), vec![2]);
+            assert_eq!(sol(&res, 13), vec![3]);
+            assert_eq!(sol(&res, 14), vec![3]);
+            assert_eq!(sol(&res, 15), vec![3]);
+            assert_eq!(sol(&res, 16), e());
+
+            let def_id = find("f", tcx);
+            let w = res.writes.remove(&def_id).unwrap();
+            assert_eq!(wg(&w, 0, 0), vec![1]);
+            assert_eq!(wg(&w, 0, 1), vec![2]);
+            assert_eq!(wg(&w, 0, 2), vec![3]);
+            assert_eq!(wg(&w, 0, 3), e());
+            assert_eq!(wg(&w, 0, 4), e());
+            assert_eq!(wg(&w, 0, 5), e());
+            assert_eq!(wg(&w, 0, 6), e());
+            assert_eq!(wg(&w, 0, 7), e());
+            assert_eq!(wg(&w, 0, 8), e());
+            assert_eq!(wg(&w, 0, 9), e());
+            assert_eq!(wg(&w, 0, 10), e());
+            assert_eq!(wg(&w, 0, 11), e());
+            assert_eq!(wg(&w, 0, 12), e());
+            assert_eq!(wg(&w, 0, 13), vec![1]);
+            assert_eq!(wg(&w, 0, 14), vec![2]);
+            assert_eq!(wg(&w, 0, 15), vec![3]);
+        },
+    );
+}
+
+#[test]
+fn test_writes_multiple() {
+    // _1 = const 0_i32
+    // _3 = &mut _1
+    // _2 = &raw mut (*_3)
+    // _5 = &mut _1
+    // _4 = &raw mut (*_5)
+    // _7 = &mut _2
+    // _6 = &raw mut (*_7)
+    // _10 = &mut _6
+    // _9 = &raw mut (*_10)
+    // _8 = move _9 as *mut libc::c_void (PtrToPtr)
+    // _12 = &mut _4
+    // _11 = &raw mut (*_12)
+    // _8 = move _11 as *mut libc::c_void (PtrToPtr)
+    // _1 = const 1_i32
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: *mut libc::c_int = &mut x;
+        let mut z: *mut libc::c_int = &mut x;
+        let mut w: *mut *mut libc::c_int = &mut y;
+        let mut v: *mut libc::c_void = &mut w as *mut *mut *mut libc::c_int
+            as *mut libc::c_void;
+        v = &mut z as *mut *mut libc::c_int as *mut libc::c_void;
+        x = 1 as libc::c_int;
+        ",
+        |mut res, tcx| {
+            assert_eq!(res.ends, v(12));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![2]);
+            assert_eq!(sol(&res, 7), vec![2]);
+            assert_eq!(sol(&res, 8), vec![4, 6]);
+            assert_eq!(sol(&res, 9), vec![6]);
+            assert_eq!(sol(&res, 10), vec![6]);
+            assert_eq!(sol(&res, 11), vec![4]);
+            assert_eq!(sol(&res, 12), vec![4]);
+
+            let def_id = find("f", tcx);
+            let w = res.writes.remove(&def_id).unwrap();
+            assert_eq!(wg(&w, 0, 0), vec![1]);
+            assert_eq!(wg(&w, 0, 1), e());
+            assert_eq!(wg(&w, 0, 2), vec![2]);
+            assert_eq!(wg(&w, 0, 3), e());
+            assert_eq!(wg(&w, 0, 4), vec![4]);
+            assert_eq!(wg(&w, 0, 5), e());
+            assert_eq!(wg(&w, 0, 6), vec![6]);
+            assert_eq!(wg(&w, 0, 7), e());
+            assert_eq!(wg(&w, 0, 8), e());
+            assert_eq!(wg(&w, 0, 9), e());
+            assert_eq!(wg(&w, 0, 10), e());
+            assert_eq!(wg(&w, 0, 11), e());
+            assert_eq!(wg(&w, 0, 12), e());
+            assert_eq!(wg(&w, 0, 13), vec![1]);
+        },
+    );
+}
+
+#[test]
+fn test_writes_ambiguous() {
+    // _1 = const 0_i32
+    // _5 = &mut _1
+    // _4 = &raw mut (*_5)
+    // _3 = s { x: move _4 }
+    // _2 = _3
+    // _7 = &mut (_2.0: *mut i32)
+    // _6 = &raw mut (*_7)
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: *mut libc::c_int,
+        }
+        ",
+        "",
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: s = {
+            let mut init = s { x: &mut x };
+            init
+        };
+        let mut z: *mut *mut libc::c_int = &mut y.x;
+        ",
+        |mut res, tcx| {
+            assert_eq!(res.ends, v(7));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![1]);
+            assert_eq!(sol(&res, 6), vec![2]);
+            assert_eq!(sol(&res, 7), vec![2]);
+
+            let def_id = find("f", tcx);
+            let w = res.writes.remove(&def_id).unwrap();
+            assert_eq!(wg(&w, 0, 0), vec![1]);
+            assert_eq!(wg(&w, 0, 1), e());
+            assert_eq!(wg(&w, 0, 2), e());
+            assert_eq!(wg(&w, 0, 3), e());
+            assert_eq!(wg(&w, 0, 4), vec![2]);
+            assert_eq!(wg(&w, 0, 5), e());
+            assert_eq!(wg(&w, 0, 6), e());
+        },
+    );
+}
+
+#[test]
+fn test_writes_double() {
+    // _1 = const 0_i32
+    // _2 = const 0_i32
+    // _4 = &mut _1
+    // _3 = &raw mut (*_4)
+    // _6 = &mut _2
+    // _5 = &raw mut (*_6)
+    // _3 = move _5
+    // (*_3) = const 1_i32
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: libc::c_int = 0 as libc::c_int;
+        let mut z: *mut libc::c_int = &mut x;
+        z = &mut y;
+        *z = 1 as libc::c_int;
+        ",
+        |mut res, tcx| {
+            assert_eq!(res.ends, v(6));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![1, 2]);
+            assert_eq!(sol(&res, 4), vec![1]);
+            assert_eq!(sol(&res, 5), vec![2]);
+            assert_eq!(sol(&res, 6), vec![2]);
+
+            let def_id = find("f", tcx);
+            let w = res.writes.remove(&def_id).unwrap();
+            assert_eq!(wg(&w, 0, 0), vec![1]);
+            assert_eq!(wg(&w, 0, 1), vec![2]);
+            assert_eq!(wg(&w, 0, 2), e());
+            assert_eq!(wg(&w, 0, 3), e());
+            assert_eq!(wg(&w, 0, 4), e());
+            assert_eq!(wg(&w, 0, 5), e());
+            assert_eq!(wg(&w, 0, 6), e());
+            assert_eq!(wg(&w, 0, 7), vec![1, 2]);
+        },
+    );
+}
+
+#[test]
+fn test_writes_malloc() {
+    // _1 = const 0_i32
+    // _3 = &mut _1
+    // _2 = &raw mut (*_3)
+    // _7 = std::mem::size_of::<*mut i32>() -> [return: bb1, unwind continue]
+    // _6 = move _7 as u64 (IntToInt)
+    // _5 = malloc(move _6) -> [return: bb2, unwind continue]
+    // _4 = move _5 as *mut *mut i32 (PtrToPtr)
+    // (*_4) = _2
+    analyze_fn(
+        "
+        let mut x: libc::c_int = 0 as libc::c_int;
+        let mut y: *mut libc::c_int = &mut x;
+        let mut z: *mut *mut libc::c_int = malloc(
+            ::std::mem::size_of::<*mut libc::c_int>() as libc::c_ulong,
+        ) as *mut *mut libc::c_int;
+        *z = y;
+        ",
+        |mut res, tcx| {
+            assert_eq!(res.ends, v(8));
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), vec![1]);
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![8]);
+            assert_eq!(sol(&res, 5), vec![8]);
+            assert_eq!(sol(&res, 6), e());
+            assert_eq!(sol(&res, 7), e());
+            assert_eq!(sol(&res, 8), vec![1]);
+
+            let def_id = find("f", tcx);
+            let w = res.writes.remove(&def_id).unwrap();
+            assert_eq!(wg(&w, 0, 0), vec![1]);
+            assert_eq!(wg(&w, 0, 1), e());
+            assert_eq!(wg(&w, 0, 2), e());
+            assert_eq!(wg(&w, 0, 3), e());
+            assert_eq!(wg(&w, 1, 0), e());
+            assert_eq!(wg(&w, 1, 1), e());
+            assert_eq!(wg(&w, 2, 0), e());
+            assert_eq!(wg(&w, 2, 1), vec![8]);
+        },
+    );
+}
+
+#[test]
+fn test_writes_field_taken() {
+    // _1 = s { x: const 0_i32, y: const 0_i32 }
+    // _3 = &mut _1
+    // _2 = &raw mut (*_3)
+    // (_1.1: i32) = const 1_i32
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: libc::c_int,
+            pub y: libc::c_int,
+        }
+        ",
+        "",
+        "
+        let mut x: s = s { x: 0, y: 0 };
+        let mut y: *mut s = &mut x;
+        x.y = 1 as libc::c_int;
+        ",
+        |mut res, tcx| {
+            assert_eq!(res.ends, vec![0, 2, 2, 3, 4]);
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![1]);
+            assert_eq!(sol(&res, 4), vec![1]);
+
+            let def_id = find("f", tcx);
+            let w = res.writes.remove(&def_id).unwrap();
+            assert_eq!(wg(&w, 0, 0), vec![1, 2]);
+            assert_eq!(wg(&w, 0, 1), e());
+            assert_eq!(wg(&w, 0, 2), e());
+            assert_eq!(wg(&w, 0, 3), vec![2]);
+        },
+    );
+}
+
+#[test]
+fn test_writes_field_untaken() {
+    // _1 = s { x: const 0_i32, y: const 0_i32 }
+    // _3 = &mut (_1.1: i32)
+    // _2 = &raw mut (*_3)
+    // (_1.0: i32) = const 2_i32
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: libc::c_int,
+            pub y: libc::c_int,
+        }
+        ",
+        "",
+        "
+        let mut x: s = s { x: 0, y: 0 };
+        let mut y: *mut libc::c_int = &mut x.y;
+        x.x = 2 as libc::c_int;
+        ",
+        |mut res, tcx| {
+            assert_eq!(res.ends, vec![0, 2, 2, 3, 4]);
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), vec![2]);
+            assert_eq!(sol(&res, 4), vec![2]);
+
+            let def_id = find("f", tcx);
+            let w = res.writes.remove(&def_id).unwrap();
+            assert_eq!(wg(&w, 0, 0), vec![2]);
+            assert_eq!(wg(&w, 0, 1), e());
+            assert_eq!(wg(&w, 0, 2), e());
+            assert_eq!(wg(&w, 0, 3), e());
+        },
+    );
+}
+
+#[test]
+fn test_writes_bitfield() {
+    // _2 = [const 0_u8]
+    // _3 = [const 0_u8; 3]
+    // _1 = s { x: const 0_i32, y_z: move _2, c2rust_padding: move _3 }
+    // _4 = copy _1
+    // (_4.0: i32) = const 1_i32
+    // _6 = &mut _4
+    // _5 = s::set_y(move _6, const 2_i32) -> [return: bb1, unwind terminate(abi)]
+    // _8 = &mut _4
+    // _7 = s::set_z(move _8, const 3_i32) -> [return: bb2, unwind terminate(abi)]
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone, BitfieldStruct)]
+        #[repr(C)]
+        pub struct s {
+            pub x: libc::c_int,
+            #[bitfield(name = \"y\", ty = \"libc::c_int\", bits = \"0..=2\")]
+            #[bitfield(name = \"z\", ty = \"libc::c_int\", bits = \"3..=7\")]
+            pub y_z: [u8; 1],
+            #[bitfield(padding)]
+            pub c2rust_padding: [u8; 3],
+        }
+        ",
+        "",
+        "
+        let mut x: s = s {
+            x: 0,
+            y_z: [0; 1],
+            c2rust_padding: [0; 3],
+        };
+        let mut y: s = x;
+        y.x = 1 as libc::c_int;
+        y.set_y(2 as libc::c_int);
+        y.set_z(3 as libc::c_int);
+        ",
+        |mut res, tcx| {
+            assert_eq!(
+                res.ends,
+                vec![0, 5, 2, 3, 4, 5, 6, 7, 12, 9, 10, 11, 12, 13, 14, 15, 16]
+            );
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), e());
+            assert_eq!(sol(&res, 4), e());
+            assert_eq!(sol(&res, 5), e());
+            assert_eq!(sol(&res, 6), e());
+            assert_eq!(sol(&res, 7), e());
+            assert_eq!(sol(&res, 8), e());
+            assert_eq!(sol(&res, 9), e());
+            assert_eq!(sol(&res, 10), e());
+            assert_eq!(sol(&res, 11), e());
+            assert_eq!(sol(&res, 12), e());
+            assert_eq!(sol(&res, 13), e());
+            assert_eq!(sol(&res, 14), vec![8]);
+            assert_eq!(sol(&res, 15), e());
+            assert_eq!(sol(&res, 16), vec![8]);
+
+            let def_id = find("f", tcx);
+            let w = res.writes.remove(&def_id).unwrap();
+            assert_eq!(wg(&w, 0, 0), e());
+            assert_eq!(wg(&w, 0, 1), e());
+            assert_eq!(wg(&w, 0, 2), e());
+            assert_eq!(wg(&w, 0, 3), vec![8, 9, 10, 11, 12]);
+            assert_eq!(wg(&w, 0, 4), vec![8]);
+            assert_eq!(wg(&w, 0, 5), e());
+            assert_eq!(wg(&w, 0, 6), e());
+            assert_eq!(wg(&w, 1, 0), e());
+            assert_eq!(wg(&w, 1, 1), e());
+            let w = res.bitfield_writes.remove(&def_id).unwrap();
+            assert_eq!(wg(&w, 0, 6), vec![11]);
+            assert_eq!(wg(&w, 1, 1), vec![12]);
+        },
+    );
+}
+
+#[test]
+fn test_writes_struct_bitfield() {
+    // _2 = s { x: const 0_i32, y: const 0_i32 }
+    // _3 = [const 0_u8]
+    // _4 = [const 0_u8; 3]
+    // _1 = t { x: move _2, y_z: move _3, c2rust_padding: move _4 }
+    // _6 = &mut _1
+    // _5 = t::set_y(move _6, const 1_i32) -> [return: bb1, unwind terminate(abi)]
+    analyze_fn_with(
+        "
+        #[derive(Copy, Clone)]
+        #[repr(C)]
+        pub struct s {
+            pub x: libc::c_int,
+            pub y: libc::c_int,
+        }
+        #[derive(Copy, Clone, BitfieldStruct)]
+        #[repr(C)]
+        pub struct t {
+            pub x: s,
+            #[bitfield(name = \"y\", ty = \"libc::c_int\", bits = \"0..=0\")]
+            #[bitfield(name = \"z\", ty = \"libc::c_int\", bits = \"1..=1\")]
+            pub y_z: [u8; 1],
+            #[bitfield(padding)]
+            pub c2rust_padding: [u8; 3],
+        }
+        ",
+        "",
+        "
+        let mut x: t = t {
+            x: s { x: 0, y: 0 },
+            y_z: [0; 1],
+            c2rust_padding: [0; 3],
+        };
+        x.set_y(1 as libc::c_int);
+        ",
+        |mut res, tcx| {
+            assert_eq!(res.ends, vec![0, 6, 2, 3, 4, 5, 6, 8, 8, 9, 10, 11, 12],);
+            assert_eq!(sol(&res, 0), e());
+            assert_eq!(sol(&res, 1), e());
+            assert_eq!(sol(&res, 2), e());
+            assert_eq!(sol(&res, 3), e());
+            assert_eq!(sol(&res, 4), e());
+            assert_eq!(sol(&res, 5), e());
+            assert_eq!(sol(&res, 6), e());
+            assert_eq!(sol(&res, 7), e());
+            assert_eq!(sol(&res, 8), e());
+            assert_eq!(sol(&res, 9), e());
+            assert_eq!(sol(&res, 10), e());
+            assert_eq!(sol(&res, 11), e());
+            assert_eq!(sol(&res, 12), vec![1]);
+
+            let def_id = find("f", tcx);
+            let w = res.writes.remove(&def_id).unwrap();
+            assert_eq!(wg(&w, 0, 0), e());
+            assert_eq!(wg(&w, 0, 1), e());
+            assert_eq!(wg(&w, 0, 2), e());
+            assert_eq!(wg(&w, 0, 3), vec![1, 2, 3, 4, 5, 6]);
+            assert_eq!(wg(&w, 0, 4), e());
+            assert_eq!(wg(&w, 0, 5), e());
+            let w = res.bitfield_writes.remove(&def_id).unwrap();
+            assert_eq!(wg(&w, 0, 5), vec![5]);
+        },
+    );
+}
+
+#[test]
+fn test_call_graph() {
+    // _1 = g() -> [return: bb1, unwind continue]
+    // _3 = _1
+    // switchInt(move _3) -> [0: bb3, otherwise: bb2]
+    // _4 = h as unsafe extern "C" fn() (PointerCoercion(ReifyFnPointer))
+    // _2 = std::option::Option::<unsafe extern "C" fn()>::Some(move _4)
+    // goto -> bb4
+    // _5 = i as unsafe extern "C" fn() (PointerCoercion(ReifyFnPointer))
+    // _2 = std::option::Option::<unsafe extern "C" fn()>::Some(move _5)
+    // goto -> bb4
+    // _9 = _2
+    // _8 = std::option::Option::<unsafe extern "C" fn()>::unwrap(move _9) -> [return: bb5, unwind continue]
+    // _7 = move _8 as fn() (Transmute)
+    // _6 = move _7() -> [return: bb6, unwind continue]
+    analyze_fn_with(
+        "
+        pub unsafe extern \"C\" fn g() -> libc::c_int {
+            return 0 as libc::c_int;
+        }
+        pub unsafe extern \"C\" fn h() {}
+        pub unsafe extern \"C\" fn i() {}
+        ",
+        "",
+        "
+            let mut x: libc::c_int = g();
+            let mut y: Option::<unsafe extern \"C\" fn() -> ()> = if x != 0 {
+                Some(
+                    ::std::mem::transmute::<
+                        unsafe extern \"C\" fn() -> (),
+                        unsafe extern \"C\" fn() -> (),
+                    >(h),
+                )
+            } else {
+                Some(
+                    ::std::mem::transmute::<
+                        unsafe extern \"C\" fn() -> (),
+                        unsafe extern \"C\" fn() -> (),
+                    >(i),
+                )
+            };
+            ::std::mem::transmute::<_, fn()>(y.unwrap())();
+        ",
+        |res, tcx| {
+            let def_id = find("f", tcx);
+            let indirect_calls = &res.indirect_calls[&def_id];
+            assert_eq!(indirect_calls.len(), 1);
+            let callees = &indirect_calls[&BasicBlock::new(5)];
+            assert_eq!(callees.len(), 2);
+            assert!(callees.contains(&find("h", tcx)));
+            assert!(callees.contains(&find("i", tcx)));
+        },
+    );
+}

--- a/src/may_analysis/tests.rs
+++ b/src/may_analysis/tests.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use rustc_hash::FxHashMap;
 use rustc_index::Idx;
 use rustc_middle::{
     mir::{BasicBlock, Location},
@@ -2292,7 +2291,7 @@ fn l(block: usize, statement_index: usize) -> Location {
 }
 
 fn wg(
-    writes: &HashMap<Location, HybridBitSet<usize>>,
+    writes: &FxHashMap<Location, HybridBitSet<usize>>,
     block: usize,
     statement_index: usize,
 ) -> Vec<usize> {

--- a/src/may_analysis/ty_shape.rs
+++ b/src/may_analysis/ty_shape.rs
@@ -1,0 +1,277 @@
+use std::collections::HashMap;
+
+use rustc_abi::FieldIdx;
+use rustc_ast::UintTy;
+use rustc_hir::{def::Res, FnRetTy, ImplItemKind, ItemKind, PrimTy, QPath, TyKind as HirTyKind};
+use rustc_middle::ty::{Ty, TyCtxt, TyKind};
+use rustc_span::def_id::{DefId, LocalDefId};
+use typed_arena::Arena;
+
+use super::analysis;
+
+pub struct TyShapes<'a, 'tcx> {
+    pub bitfields: HashMap<LocalDefId, BitField>,
+    pub tys: HashMap<Ty<'tcx>, &'a TyShape<'a>>,
+    prim: &'a TyShape<'a>,
+    arena: &'a Arena<TyShape<'a>>,
+}
+
+impl std::fmt::Debug for TyShapes<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TyShapes")
+            .field("bitfields", &self.bitfields)
+            .field("tys", &self.tys)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct BitField {
+    pub name_to_idx: HashMap<String, FieldIdx>,
+    pub fields: HashMap<FieldIdx, (String, String)>,
+}
+
+impl BitField {
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.fields.len()
+    }
+}
+
+pub fn get_ty_shapes<'a, 'tcx>(
+    arena: &'a Arena<TyShape<'a>>,
+    tcx: TyCtxt<'tcx>,
+) -> TyShapes<'a, 'tcx> {
+    let prim = arena.alloc(TyShape::Primitive);
+    let mut tss = TyShapes {
+        bitfields: HashMap::new(),
+        tys: HashMap::new(),
+        prim,
+        arena,
+    };
+    compute_bitfields(&mut tss, tcx);
+    compute_ty_shapes(&mut tss, tcx);
+    tss
+}
+
+fn compute_bitfields<'tcx>(tss: &mut TyShapes<'_, 'tcx>, tcx: TyCtxt<'tcx>) {
+    let mut bitfield_structs = HashMap::new();
+    let mut bitfield_impls = HashMap::new();
+    for item_id in tcx.hir_free_items() {
+        let item = tcx.hir_item(item_id);
+        match item.kind {
+            ItemKind::Struct(vd, _) => {
+                for field in vd.fields() {
+                    let HirTyKind::Array(ty, _) = field.ty.kind else {
+                        continue;
+                    };
+                    let HirTyKind::Path(QPath::Resolved(_, path)) = ty.kind else {
+                        continue;
+                    };
+                    if !matches!(path.res, Res::PrimTy(PrimTy::Uint(UintTy::U8))) {
+                        continue;
+                    }
+                    let name = field.ident.name.to_ident_string();
+                    if !name.starts_with("c2rust_padding") {
+                        let len = vd.fields().len();
+                        bitfield_structs.insert(item_id.owner_id.def_id, (name, len));
+                        break;
+                    }
+                }
+            }
+            ItemKind::Impl(imp) if imp.of_trait.is_none() => {
+                let HirTyKind::Path(QPath::Resolved(_, path)) = imp.self_ty.kind else {
+                    unreachable!()
+                };
+                let Res::Def(_, def_id) = path.res else {
+                    unreachable!()
+                };
+                let local_def_id = def_id.expect_local();
+                let fields: Vec<_> = imp
+                    .items
+                    .chunks(2)
+                    .map(|items| {
+                        let name0 = items[0].ident.name.to_ident_string();
+                        let name0 = name0.strip_prefix("set_").unwrap();
+                        let name1 = items[1].ident.name.to_ident_string();
+                        assert_eq!(name0, name1);
+                        let ImplItemKind::Fn(sig, _) = tcx.hir_impl_item(items[1].id).kind else {
+                            unreachable!()
+                        };
+                        let FnRetTy::Return(ty) = sig.decl.output else {
+                            unreachable!()
+                        };
+                        let rustc_hir::TyKind::Path(QPath::Resolved(_, path)) = ty.kind else {
+                            unreachable!()
+                        };
+                        let ty: String = path
+                            .segments
+                            .iter()
+                            .map(|seg| seg.ident.name.to_ident_string())
+                            .intersperse("::".to_string())
+                            .collect();
+                        (name1, ty)
+                    })
+                    .collect();
+                bitfield_impls.insert(local_def_id, fields);
+            }
+            _ => {}
+        }
+    }
+    tss.bitfields = bitfield_impls
+        .into_iter()
+        .map(|(ty, fields)| {
+            let bf1: String = fields
+                .iter()
+                .map(|(f, _)| f.as_str())
+                .intersperse("_")
+                .collect();
+            let (ref bf2, len) = bitfield_structs[&ty];
+            assert_eq!(&bf1, bf2);
+            let name_to_idx = fields
+                .iter()
+                .enumerate()
+                .map(|(i, (f, _))| (f.clone(), FieldIdx::from_usize(len + i)))
+                .collect();
+            let fields = fields
+                .into_iter()
+                .enumerate()
+                .map(|(i, p)| (FieldIdx::from_usize(len + i), p))
+                .collect();
+            let bitfield = BitField {
+                name_to_idx,
+                fields,
+            };
+            (ty, bitfield)
+        })
+        .collect();
+}
+
+fn compute_ty_shapes<'tcx>(tss: &mut TyShapes<'_, 'tcx>, tcx: TyCtxt<'tcx>) {
+    for item_id in tcx.hir_free_items() {
+        let item = tcx.hir_item(item_id);
+        let local_def_id = item.owner_id.def_id;
+        let def_id = local_def_id.to_def_id();
+        let body = match item.kind {
+            ItemKind::Fn { .. } if item.ident.name.as_str() != "main" => tcx.optimized_mir(def_id),
+            ItemKind::Static(_, _, _) => tcx.mir_for_ctfe(def_id),
+            _ => continue,
+        };
+        for local_decl in body.local_decls.iter() {
+            compute_ty_shape(local_decl.ty, def_id, tss, tcx);
+            if let Some(ty) = analysis::unwrap_ptr(local_decl.ty) {
+                compute_ty_shape(ty, def_id, tss, tcx);
+            }
+        }
+    }
+}
+
+fn compute_ty_shape<'a, 'tcx>(
+    ty: Ty<'tcx>,
+    owner: DefId,
+    tss: &mut TyShapes<'a, 'tcx>,
+    tcx: TyCtxt<'tcx>,
+) -> &'a TyShape<'a> {
+    if let Some(ts) = tss.tys.get(&ty) {
+        return ts;
+    }
+    let ts = match ty.kind() {
+        TyKind::Adt(adt_def, generic_args) => {
+            if ty.is_c_void(tcx) {
+                tss.prim
+            } else {
+                let tys = adt_def.variants().iter().flat_map(|variant| {
+                    variant
+                        .fields
+                        .iter()
+                        .map(|field| field.ty(tcx, generic_args))
+                });
+                let bitfield_len = adt_def
+                    .did()
+                    .as_local()
+                    .and_then(|local_def_id| tss.bitfields.get(&local_def_id))
+                    .map(|fields| fields.len())
+                    .unwrap_or_default();
+                let is_union = adt_def.is_union();
+                compute_ty_shape_many(tys, bitfield_len, is_union, owner, tss, tcx)
+            }
+        }
+        TyKind::Array(ty, len) => {
+            let t = compute_ty_shape(*ty, owner, tss, tcx);
+            let len = len.try_to_target_usize(tcx).unwrap() as usize;
+            tss.arena.alloc(TyShape::Array(t, len))
+        }
+        TyKind::Tuple(tys) => compute_ty_shape_many(tys.iter(), 0, false, owner, tss, tcx),
+        _ => tss.prim,
+    };
+    tss.tys.insert(ty, ts);
+    assert_ne!(ts.len(), 0);
+    ts
+}
+
+#[inline]
+fn compute_ty_shape_many<'a, 'tcx, I: Iterator<Item = Ty<'tcx>>>(
+    tys: I,
+    bitfield_len: usize,
+    is_union: bool,
+    owner: DefId,
+    tss: &mut TyShapes<'a, 'tcx>,
+    tcx: TyCtxt<'tcx>,
+) -> &'a TyShape<'a> {
+    let mut len = 0;
+    let mut fields = vec![];
+    for ty in tys {
+        let ts = compute_ty_shape(ty, owner, tss, tcx);
+        fields.push((len, ts));
+        len += ts.len();
+    }
+    for _ in 0..bitfield_len {
+        fields.push((len, tss.prim));
+        len += 1;
+    }
+    if len == 0 {
+        tss.prim
+    } else {
+        tss.arena.alloc(TyShape::Struct(len, fields, is_union))
+    }
+}
+
+#[allow(variant_size_differences)]
+pub enum TyShape<'a> {
+    Primitive,
+    Array(&'a TyShape<'a>, usize),
+    Struct(usize, Vec<(usize, &'a TyShape<'a>)>, bool),
+}
+
+impl std::fmt::Debug for TyShape<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Primitive => write!(f, "*"),
+            Self::Array(t, len) => write!(f, "[{:?}; {}]", t, len),
+            Self::Struct(len, fields, is_union) => {
+                write!(f, "{{{}", len)?;
+                for (i, ts) in fields {
+                    let sep = if *i == 0 { ";" } else { "," };
+                    write!(f, "{} {}: {:?}", sep, i, ts)?;
+                }
+                write!(f, "}}")?;
+                if *is_union {
+                    write!(f, "u")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl TyShape<'_> {
+    #[inline]
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Primitive => 1,
+            Self::Array(t, _) => t.len(),
+            Self::Struct(len, _, _) => *len,
+        }
+    }
+}


### PR DESCRIPTION
related #9 

수정 사항:
- pre-analysis 추가: urcrat의 may-analysis 코드 사용
  - 일부 데이터 구조 HashSet -> FxHashSet으로 변경
  - 분석 결과 사용하여 alias 정보 계산하는 함수 `compute_alias` 추가
  - 타입 체크시에 사용할 타입 정보를 가져오기 위해, ty_shape의 `Primitive` 에 타입 정보 추가
- 분석 semantic에 alias checking 추가 
- 분석 state에 `alias_excludes` 추가 
  - caller의 개수가 많은 함수 (util 함수 등) 가 있을 경우, 해당 함수에 alias checking으로 추가된 exclude가 모든 caller에 영향을 끼침. 이러한 상황을 막기 위해, intra call에서 호출하는 argument의 may-points-to 정보가 비어있는지 아닌지 여부를 확인. 
  
  
테스트 ([Result](https://docs.google.com/spreadsheets/d/1XBuFY-R_axHFkJ_0-o1Zig_KV1M8cTKMuyLDR8hLe9Q/edit?usp=sharing)) :
- A: static variable만 detect
- B: static variable만 detect, parameter끼리 aliases인 경우 포함 (현재 코드 버전)
- C: local 포함 모두 detect (현재 코드 --strict-alias 옵션 버전)


아래는 삭제된 것들 중 TN cases:
- tar-1.34: src::list::decode_header
- screen-4.9.0: window::nwin_compose
  - Parameter끼리 alias
  ```nwin_compose(&mut nwin_default, &mut nwin_options, &mut nwin_default);```

아래는 FN cases의 원인:
- type checking으로 거를 수 없는 경우 (예: 변수와 parameter가 가리키는 타입의 사이즈가 같은 경우, 서로 alias인지 아닌지 타입으로는 구분 불가함)
- 함수 내부에서 생성된 alias이지만, dereference 시 state에 저장된 pointer base가 Arg(...)가 아닌 경우
- 함수 내부에서 static 변수에 접근함. 그러나 static 변수의 address가 argument로 들어왔을 때는 실행 시 해당 변수에 접근하지 않는 경우. 
  - uucp-1.07 : protg::fgexchange_init 
  - gprolog-1.5.0 : BipsPl::debugger_c::Modify_Wam_Word
