### PR TITLE
Fix detection of non-null locations 

### DIFF
--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -761,28 +761,40 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
     fn compute_nonnull_null_locs(
         &self,
         result: &BTreeMap<Location, BTreeMap<(MustPathSet, AbsNulls), AbsState>>,
-    ) -> Vec<(BTreeSet<Location>, BTreeSet<Location>, BTreeSet<Location>)> {
+    ) -> Vec<(BTreeSet<Location>, BTreeSet<Location>)> {
         let inputs = self.info.inputs;
         let mut locs = vec![];
 
         for i in 1..=inputs {
             let mut nonnull_locs = BTreeSet::new();
             let mut null_locs = BTreeSet::new();
-            let mut top_locs = BTreeSet::new();
+            // collection of locations except non-null or null
+            let mut non_nonnull_locs = BTreeSet::new();
+            let mut non_null_locs = BTreeSet::new();
             for (loc, sts) in result {
                 for (_, nulls) in sts.keys() {
                     if let Some(arg) = self.ptr_params_inv.get(&i) {
-                        if nulls.is_null(arg) {
-                            null_locs.insert(*loc);
-                        } else if nulls.is_nonnull(arg) {
-                            nonnull_locs.insert(*loc);
-                        } else {
-                            top_locs.insert(*loc);
+                        match nulls.get(*arg) {
+                            AbsNull::Null(_) => {
+                                null_locs.insert(*loc);
+                                non_nonnull_locs.insert(*loc);
+                            }
+                            AbsNull::Nonnull(_) => {
+                                nonnull_locs.insert(*loc);
+                                non_null_locs.insert(*loc);
+                            }
+                            AbsNull::Top => {
+                                non_nonnull_locs.insert(*loc);
+                                non_null_locs.insert(*loc);
+                            }
                         }
                     }
                 }
             }
-            locs.push((nonnull_locs, null_locs, top_locs));
+
+            let nonnull_locs = nonnull_locs.difference(&non_nonnull_locs).cloned().collect();
+            let null_locs = null_locs.difference(&non_null_locs).cloned().collect();
+            locs.push((nonnull_locs, null_locs));
         }
         locs
     }
@@ -801,15 +813,13 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
         self.compute_nonnull_null_locs(result)
             .into_iter()
             .enumerate()
-            .filter_map(|(i, (nonnull, null, top))| {
+            .filter_map(|(i, (nonnull, null))| {
                 if null.is_empty() && nonnull.is_empty() {
                     return None;
                 }
 
                 let param = i + 1;
-                let comp_null = nonnull.union(&null).cloned().collect::<BTreeSet<_>>();
-                let comp_nonnull = null.union(&top).cloned().collect::<BTreeSet<_>>();
-                let nonnull_diff = nonnull.difference(&comp_nonnull).cloned().fold(
+                let nonnull_diff = nonnull.into_iter().fold(
                     BTreeMap::new(),
                     |mut acc: BTreeMap<BasicBlock, BTreeSet<Location>>, loc| {
                         acc.entry(loc.block).or_default().insert(loc);
@@ -817,7 +827,7 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
                     },
                 );
                 let nonnull_locs = nonnull_diff.values().flatten().collect::<BTreeSet<_>>();
-                let null_diff = null.difference(&comp_null).cloned().fold(
+                let null_diff = null.into_iter().fold(
                     BTreeMap::new(),
                     |mut acc: BTreeMap<BasicBlock, BTreeSet<Location>>, loc| {
                         acc.entry(loc.block).or_default().insert(loc);
@@ -825,8 +835,6 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
                     },
                 );
                 let null_locs = null_diff.values().flatten().collect::<BTreeSet<_>>();
-                println!("{:?}", null_locs);
-                println!("{:?}", nonnull_locs);
 
                 let check = |block, locs: &BTreeSet<_>, diff_locs| {
                     let mut local_writes = BTreeSet::new();

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -629,7 +629,7 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
         tcx: TyCtxt<'tcx>,
         body: &Body<'tcx>,
         block: &BasicBlock,
-        locs: &BTreeSet<&Location>,
+        locs: &BTreeSet<Location>,
         locals: &BTreeSet<Local>,
     ) -> bool {
         if locals.is_empty() {
@@ -817,22 +817,20 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
                 }
 
                 let param = i + 1;
-                let nonnull_diff = nonnull.into_iter().fold(
+                let nonnull_diff = nonnull.iter().fold(
                     BTreeMap::new(),
                     |mut acc: BTreeMap<BasicBlock, BTreeSet<Location>>, loc| {
-                        acc.entry(loc.block).or_default().insert(loc);
+                        acc.entry(loc.block).or_default().insert(*loc);
                         acc
                     },
                 );
-                let nonnull_locs = nonnull_diff.values().flatten().collect::<BTreeSet<_>>();
-                let null_diff = null.into_iter().fold(
+                let null_diff = null.iter().fold(
                     BTreeMap::new(),
                     |mut acc: BTreeMap<BasicBlock, BTreeSet<Location>>, loc| {
-                        acc.entry(loc.block).or_default().insert(loc);
+                        acc.entry(loc.block).or_default().insert(*loc);
                         acc
                     },
                 );
-                let null_locs = null_diff.values().flatten().collect::<BTreeSet<_>>();
 
                 let check = |block, locs: &BTreeSet<_>, diff_locs| {
                     let mut local_writes = BTreeSet::new();
@@ -865,8 +863,8 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
                 };
                 if nonnull_diff
                     .iter()
-                    .all(|(b, locs)| check(b, locs, &nonnull_locs))
-                    && null_diff.iter().all(|(b, locs)| check(b, locs, &null_locs))
+                    .all(|(b, locs)| check(b, locs, &nonnull))
+                    && null_diff.iter().all(|(b, locs)| check(b, locs, &null))
                 {
                     None
                 } else {

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -792,7 +792,10 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
                 }
             }
 
-            let nonnull_locs = nonnull_locs.difference(&non_nonnull_locs).cloned().collect();
+            let nonnull_locs = nonnull_locs
+                .difference(&non_nonnull_locs)
+                .cloned()
+                .collect();
             let null_locs = null_locs.difference(&non_null_locs).cloned().collect();
             locs.push((nonnull_locs, null_locs));
         }

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -309,13 +309,8 @@ pub fn analyze(
                     );
                 }
 
-                let mut nullable_params = analyzer.find_nullable_params(
-                    tcx,
-                    &states,
-                    body,
-                    &writes_map,
-                    &call_info_map,
-                );
+                let mut nullable_params =
+                    analyzer.find_nullable_params(tcx, &states, body, &writes_map, &call_info_map);
 
                 if conf.check_global_alias {
                     let alias_params = analyzer.check_reachable_globals(

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -764,46 +764,9 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
             .collect::<BTreeSet<_>>()
     }
 
-    fn is_reachable_from(&self, loc: &Location, check: &Location, body: &Body<'_>) -> bool {
-        if check.block == loc.block {
-            // loc and check should be different
-            return check.statement_index < loc.statement_index;
-        }
-
-        let dominators = body.basic_blocks.dominators();
-
-        if dominators.dominates(check.block, loc.block) {
-            return true;
-        }
-
-        let mut visited = BTreeSet::new();
-        let mut work_list = VecDeque::from(vec![check.block]);
-        while let Some(bb) = work_list.pop_front() {
-            if bb == loc.block {
-                return true;
-            }
-            // If we reach a loop head, stop searching that path
-            if self.info.loop_blocks.contains_key(&bb)
-                && self.info.loop_blocks[&bb].contains(&check.block)
-            {
-                continue;
-            }
-            if visited.insert(bb) {
-                work_list.extend(body.basic_blocks.successors(bb));
-            }
-        }
-        false
-    }
-
     // To derive the set of non-null locations, we check the location is reachable from
     // any null check (is_null) location
-    fn compute_reachable_locs(
-        &self,
-        body: &Body<'_>,
-        diff_locs: BTreeSet<Location>,
-        param: usize,
-    ) -> BTreeMap<BasicBlock, BTreeSet<Location>> {
-        let mut reachable_group: BTreeMap<BasicBlock, BTreeSet<Location>> = BTreeMap::new();
+    fn compute_reachable_locs(&self) -> BTreeMap<BasicBlock, BTreeSet<Location>> {
         // TODO
         // if let Some(null_checks) = null_checks_map.get(&param) {
         //     for loc in diff_locs {
@@ -816,7 +779,7 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
         //         }
         //     }
         // }
-        reachable_group
+        BTreeMap::new()
     }
 
     // Compute locations where the parameters are non-null or null
@@ -859,16 +822,14 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
             .into_iter()
             .zip(null_locs)
             .enumerate()
-            .filter_map(|(i, (nonnull, null))| {
+            .filter_map(|(i, (_nonnull, null))| {
                 if null.is_empty() {
                     return None;
                 }
 
                 let param = i + 1;
-                let nonnull_diff =
-                    self.compute_reachable_locs(body, &nonnull - &null, param);
-                let null_diff =
-                    self.compute_reachable_locs(body, &null - &nonnull, param);
+                let nonnull_diff = self.compute_reachable_locs();
+                let null_diff = self.compute_reachable_locs();
                 let nonnull_locs = self.extract_locs(&nonnull_diff);
                 let null_locs = self.extract_locs(&null_diff);
 

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -775,11 +775,11 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
                 for (_, nulls) in sts.keys() {
                     if let Some(arg) = self.ptr_params_inv.get(&i) {
                         match nulls.get(*arg) {
-                            AbsNull::Null(_) => {
+                            AbsNull::Null => {
                                 null_locs.insert(*loc);
                                 non_nonnull_locs.insert(*loc);
                             }
-                            AbsNull::Nonnull(_) => {
+                            AbsNull::Nonnull => {
                                 nonnull_locs.insert(*loc);
                                 non_null_locs.insert(*loc);
                             }

--- a/src/ai/domains.rs
+++ b/src/ai/domains.rs
@@ -3297,7 +3297,7 @@ impl AbsNulls {
             (0..self.0.len().max(other.0.len()))
                 .map(|i| match (self.0.get(i), other.0.get(i)) {
                     (Some(n1), Some(n2)) => n1.join(n2),
-                    (Some(_), None) | (None, Some(_)) => AbsNull::top(),
+                    (Some(n), None) | (None, Some(n)) => *n,
                     (None, None) => unreachable!(),
                 })
                 .collect(),
@@ -3309,7 +3309,7 @@ impl AbsNulls {
             (0..self.0.len().max(other.0.len()))
                 .map(|i| match (self.0.get(i), other.0.get(i)) {
                     (Some(n1), Some(n2)) => n1.widen(n2),
-                    (Some(_), None) | (None, Some(_)) => AbsNull::top(),
+                    (Some(n), None) | (None, Some(n)) => *n,
                     (None, None) => unreachable!(),
                 })
                 .collect(),
@@ -3352,6 +3352,14 @@ impl AbsNulls {
     pub fn is_null(&self, arg: &usize) -> bool {
         if let Some(n) = self.0.get(*arg) {
             matches!(n, AbsNull::Null(_))
+        } else {
+            false
+        }
+    }
+
+    pub fn is_nonnull(&self, arg: &usize) -> bool {
+        if let Some(n) = self.0.get(*arg) {
+            matches!(n, AbsNull::Nonnull(_))
         } else {
             false
         }

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -546,7 +546,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                                 return (
                                     vec![AbsValue::bool_true(), AbsValue::bool_false()],
                                     vec![(i, arg, AbsNull::null()), (i, arg, AbsNull::nonnull())],
-                                call_kind,
+                                    call_kind,
                                 );
                             }
                         }

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -52,17 +52,17 @@ impl TransferedTerminator {
 
     #[inline]
     fn empty() -> Self {
-        Self::new(vec![], vec![], BTreeSet::new(),vec![])
+        Self::new(vec![], vec![], BTreeSet::new(), vec![])
     }
 
     #[inline]
     fn state_location(st: AbsState, loc: Location) -> Self {
-        Self::new(vec![st], vec![loc], BTreeSet::new(),vec![])
+        Self::new(vec![st], vec![loc], BTreeSet::new(), vec![])
     }
 
     #[inline]
     fn state_locations(st: AbsState, locs: Vec<Location>) -> Self {
-        Self::new(vec![st], locs, BTreeSet::new(),vec![])
+        Self::new(vec![st], locs, BTreeSet::new(), vec![])
     }
 }
 
@@ -151,9 +151,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                     reads.extend(reads2);
                 }
 
-                let (new_states, writes, call_info) = if let Some(fns) =
-                    func.fnv.gamma()
-                {
+                let (new_states, writes, call_info) = if let Some(fns) = func.fnv.gamma() {
                     let mut new_states_map: BTreeMap<_, Vec<_>> = BTreeMap::new();
                     let mut ret_writes = BTreeSet::new();
                     let mut call_info = vec![];
@@ -235,25 +233,24 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
         let mut offsets = vec![];
         let mut writes = vec![];
         let name = self.def_id_to_string(callee);
-        let (vns, call_kind) = if callee.is_local() {
+        let (vs, nulls, call_kind) = if callee.is_local() {
             if let Some(summary) = self.summaries.get(&callee) {
                 return self
                     .transfer_intra_call(callee, summary, args, dst, state, location, reads);
             } else if name.contains("{extern#0}") {
                 (
-                    vec![(
-                        self.transfer_c_call(callee, args, &mut state, &mut reads),
-                        None,
-                    )],
+                    vec![self.transfer_c_call(callee, args, &mut state, &mut reads)],
+                    None,
                     CallKind::C,
                 )
             } else if name.contains("{impl#") {
                 (
-                    vec![(self.transfer_method_call(callee, args, &mut reads), None)],
+                    vec![self.transfer_method_call(callee, args, &mut reads)],
+                    None,
                     CallKind::Method,
                 )
             } else {
-                (vec![(AbsValue::top(), None)], CallKind::TOP)
+                (vec![AbsValue::top()], None, CallKind::TOP)
             }
         } else {
             self.transfer_rust_call(
@@ -265,19 +262,30 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                 &mut writes,
             )
         };
-        let (new_states, writess): (Vec<_>, Vec<_>) = vns
+        let (mut new_states, writess): (Vec<_>, Vec<_>) = vs
             .into_iter()
-            .map(|(v, null)| {
+            .map(|v| {
                 let (mut new_state, writes_ret) = self.assign(dst, v, &state);
                 new_state.add_excludes(offsets.iter().cloned());
                 new_state.add_reads(reads.iter().cloned());
                 let writes = new_state.add_writes(writes.iter().cloned().chain(writes_ret));
-                if let Some((i, n)) = null {
-                    new_state.add_null(i, n);
-                }
                 (new_state, writes)
             })
             .unzip();
+
+        if let Some(nulls) = nulls {
+            assert!(new_states.len() == nulls.len());
+            new_states.iter_mut().zip(nulls).for_each(|(state, n)| {
+                match n {
+                    AbsNull::Null(i) | AbsNull::Nonnull(i) => {
+                        let arg = self.ptr_params_inv.get(&i).unwrap();
+                        state.add_null(*arg, n);
+                    }
+                    AbsNull::Top => (), // Top is not added to nulls
+                }
+            });
+        }
+
         let writes = writess.into_iter().flatten().collect();
         (new_states, writes, call_kind)
     }
@@ -466,7 +474,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
         offsets: &mut Vec<AbsPath>,
         reads: &mut Vec<AbsPath>,
         writes: &mut Vec<AbsPath>,
-    ) -> (Vec<(AbsValue, Option<(usize, AbsNull)>)>, CallKind) {
+    ) -> (Vec<AbsValue>, Option<Vec<AbsNull>>, CallKind) {
         let name = self.def_id_to_string(callee);
         let mut call_kind = CallKind::RustPure;
         let mut segs: Vec<_> = name.split("::").collect();
@@ -530,10 +538,8 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                     if args.len() == 1 && !t {
                         let arg = *args.first().unwrap();
                         return (
-                            vec![
-                                (AbsValue::bool_true(), Some((arg, AbsNull::Null))),
-                                (AbsValue::bool_false(), Some((arg, AbsNull::Nonnull))),
-                            ],
+                            vec![AbsValue::bool_true(), AbsValue::bool_false()],
+                            Some(vec![AbsNull::null(arg), AbsNull::nonnull(arg)]),
                             call_kind,
                         );
                     }
@@ -676,7 +682,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
             }
             _ => todo!("{}", name),
         };
-        (vec![(v, None)], call_kind)
+        (vec![v], None, call_kind)
     }
 
     fn transfer_rvalue(

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -21,7 +21,6 @@ pub struct TransferedTerminator {
     pub next_states: Vec<AbsState>,
     pub next_locations: Vec<Location>,
     pub writes: BTreeSet<AbsPath>,
-    pub null_check: Option<usize>,
     pub call_info: Vec<CallKind>,
 }
 
@@ -41,31 +40,29 @@ impl TransferedTerminator {
         next_states: Vec<AbsState>,
         next_locations: Vec<Location>,
         writes: BTreeSet<AbsPath>,
-        null_check: Option<usize>,
         call_info: Vec<CallKind>,
     ) -> Self {
         Self {
             next_states,
             next_locations,
             writes,
-            null_check,
             call_info,
         }
     }
 
     #[inline]
     fn empty() -> Self {
-        Self::new(vec![], vec![], BTreeSet::new(), None, vec![])
+        Self::new(vec![], vec![], BTreeSet::new(),vec![])
     }
 
     #[inline]
     fn state_location(st: AbsState, loc: Location) -> Self {
-        Self::new(vec![st], vec![loc], BTreeSet::new(), None, vec![])
+        Self::new(vec![st], vec![loc], BTreeSet::new(),vec![])
     }
 
     #[inline]
     fn state_locations(st: AbsState, locs: Vec<Location>) -> Self {
-        Self::new(vec![st], locs, BTreeSet::new(), None, vec![])
+        Self::new(vec![st], locs, BTreeSet::new(),vec![])
     }
 }
 
@@ -154,15 +151,14 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                     reads.extend(reads2);
                 }
 
-                let (new_states, writes, null_check, call_info) = if let Some(fns) =
+                let (new_states, writes, call_info) = if let Some(fns) =
                     func.fnv.gamma()
                 {
                     let mut new_states_map: BTreeMap<_, Vec<_>> = BTreeMap::new();
                     let mut ret_writes = BTreeSet::new();
                     let mut call_info = vec![];
-                    let mut null_check = None;
                     for def_id in fns {
-                        let (states, writes, null_arg, call_kind) = self.transfer_call(
+                        let (states, writes, call_kind) = self.transfer_call(
                             *def_id,
                             &args,
                             destination,
@@ -173,10 +169,6 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                         ret_writes.extend(writes);
                         call_info.push(call_kind);
 
-                        if let Some(arg) = null_arg {
-                            null_check = Some(arg);
-                        }
-
                         for state in states {
                             let wn = (state.writes.clone(), state.nulls.clone());
                             new_states_map.entry(wn).or_default().push(state);
@@ -186,7 +178,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                         .into_values()
                         .map(|states| states.into_iter().reduce(|a, b| a.join(&b)).unwrap())
                         .collect();
-                    (new_states, ret_writes, null_check, call_info)
+                    (new_states, ret_writes, call_info)
                 } else {
                     let (mut new_state, writes) = self.assign(destination, AbsValue::top(), state);
                     let reads2 = args
@@ -198,7 +190,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                     for arg in &args {
                         self.indirect_assign(&arg.ptrv, &AbsValue::top(), &[], &mut new_state);
                     }
-                    (vec![new_state], writes, None, vec![])
+                    (vec![new_state], writes, vec![])
                 };
                 let locations = if new_states.is_empty() {
                     vec![]
@@ -208,7 +200,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                         .map(|target| vec![target.start_location()])
                         .unwrap_or(vec![])
                 };
-                TransferedTerminator::new(new_states, locations, writes, null_check, call_info)
+                TransferedTerminator::new(new_states, locations, writes, call_info)
             }
             TerminatorKind::TailCall { .. } => todo!("{:?}", terminator.kind),
             TerminatorKind::Assert { cond, target, .. } => {
@@ -239,10 +231,9 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
         location: Location,
         mut state: AbsState,
         mut reads: Vec<AbsPath>,
-    ) -> (Vec<AbsState>, BTreeSet<AbsPath>, Option<usize>, CallKind) {
+    ) -> (Vec<AbsState>, BTreeSet<AbsPath>, CallKind) {
         let mut offsets = vec![];
         let mut writes = vec![];
-        let mut null_check = None;
         let name = self.def_id_to_string(callee);
         let (vns, call_kind) = if callee.is_local() {
             if let Some(summary) = self.summaries.get(&callee) {
@@ -281,15 +272,14 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                 new_state.add_excludes(offsets.iter().cloned());
                 new_state.add_reads(reads.iter().cloned());
                 let writes = new_state.add_writes(writes.iter().cloned().chain(writes_ret));
-                if let Some(null) = null {
-                    new_state.add_null(null);
-                    null_check = Some(null);
+                if let Some((i, n)) = null {
+                    new_state.add_null(i, n);
                 }
                 (new_state, writes)
             })
             .unzip();
         let writes = writess.into_iter().flatten().collect();
-        (new_states, writes, null_check, call_kind)
+        (new_states, writes, call_kind)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -302,9 +292,9 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
         state: AbsState,
         location: Location,
         mut reads: Vec<AbsPath>,
-    ) -> (Vec<AbsState>, BTreeSet<AbsPath>, Option<usize>, CallKind) {
+    ) -> (Vec<AbsState>, BTreeSet<AbsPath>, CallKind) {
         if summary.return_states.is_empty() {
-            return (vec![], BTreeSet::new(), None, CallKind::Intra);
+            return (vec![], BTreeSet::new(), CallKind::Intra);
         }
 
         let mut ptr_maps = BTreeMap::new();
@@ -371,7 +361,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
             ret_writes.extend(writes);
             states.push(state)
         }
-        (states, ret_writes, None, CallKind::Intra)
+        (states, ret_writes, CallKind::Intra)
     }
 
     fn transfer_method_call(
@@ -476,7 +466,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
         offsets: &mut Vec<AbsPath>,
         reads: &mut Vec<AbsPath>,
         writes: &mut Vec<AbsPath>,
-    ) -> (Vec<(AbsValue, Option<usize>)>, CallKind) {
+    ) -> (Vec<(AbsValue, Option<(usize, AbsNull)>)>, CallKind) {
         let name = self.def_id_to_string(callee);
         let mut call_kind = CallKind::RustPure;
         let mut segs: Vec<_> = name.split("::").collect();
@@ -541,8 +531,8 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                         let arg = *args.first().unwrap();
                         return (
                             vec![
-                                (AbsValue::bool_true(), Some(arg)),
-                                (AbsValue::bool_false(), None),
+                                (AbsValue::bool_true(), Some((arg, AbsNull::Null))),
+                                (AbsValue::bool_false(), Some((arg, AbsNull::Nonnull))),
                             ],
                             call_kind,
                         );

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -275,16 +275,15 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
 
         if !nulls.is_empty() {
             assert!(new_states.len() == nulls.len());
-            new_states
-                .iter_mut()
-                .zip(nulls)
-                .for_each(|(state, (i, arg, n))| match n {
+            for (state, (i, arg, n)) in new_states.iter_mut().zip(nulls) {
+                match n {
                     AbsNull::Top => unreachable!(),
                     AbsNull::Null | AbsNull::Nonnull => {
                         let path = AbsPath(vec![i]);
                         state.add_null(path, arg, n);
                     }
-                });
+                }
+            }
         }
 
         let writes = writess.into_iter().flatten().collect();

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -240,17 +240,17 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
             } else if name.contains("{extern#0}") {
                 (
                     vec![self.transfer_c_call(callee, args, &mut state, &mut reads)],
-                    None,
+                    vec![],
                     CallKind::C,
                 )
             } else if name.contains("{impl#") {
                 (
                     vec![self.transfer_method_call(callee, args, &mut reads)],
-                    None,
+                    vec![],
                     CallKind::Method,
                 )
             } else {
-                (vec![AbsValue::top()], None, CallKind::TOP)
+                (vec![AbsValue::top()], vec![], CallKind::TOP)
             }
         } else {
             self.transfer_rust_call(
@@ -273,17 +273,17 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
             })
             .unzip();
 
-        if let Some(nulls) = nulls {
+        if !nulls.is_empty() {
             assert!(new_states.len() == nulls.len());
             new_states
                 .iter_mut()
                 .zip(nulls)
-                .for_each(|(state, n)| match n {
-                    AbsNull::Null(i) | AbsNull::Nonnull(i) => {
-                        let arg = self.ptr_params_inv.get(&i).unwrap();
-                        state.add_null(*arg, n);
-                    }
+                .for_each(|(state, (i, arg, n))| match n {
                     AbsNull::Top => unreachable!(),
+                    AbsNull::Null | AbsNull::Nonnull => {
+                        let path = AbsPath(vec![i]);
+                        state.add_null(path, arg, n);
+                    }
                 });
         }
 
@@ -475,7 +475,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
         offsets: &mut Vec<AbsPath>,
         reads: &mut Vec<AbsPath>,
         writes: &mut Vec<AbsPath>,
-    ) -> (Vec<AbsValue>, Option<Vec<AbsNull>>, CallKind) {
+    ) -> (Vec<AbsValue>, Vec<(usize, usize, AbsNull)>, CallKind) {
         let name = self.def_id_to_string(callee);
         let mut call_kind = CallKind::RustPure;
         let mut segs: Vec<_> = name.split("::").collect();
@@ -537,18 +537,26 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                         })
                         .collect();
                     if args.len() == 1 && !t {
-                        let arg = *args.first().unwrap();
-                        return (
-                            vec![AbsValue::bool_true(), AbsValue::bool_false()],
-                            Some(vec![AbsNull::null(arg), AbsNull::nonnull(arg)]),
-                            call_kind,
-                        );
-                    }
-                    match (t, f) {
-                        (true, true) => AbsValue::top_bool(),
-                        (true, false) => AbsValue::bool_true(),
-                        (false, true) => AbsValue::bool_false(),
-                        (false, false) => AbsValue::bot(),
+                        let i = *args.first().unwrap();
+                        let arg = *self.ptr_params_inv.get(&i).unwrap();
+                        match state.nulls.get(arg) {
+                            AbsNull::Null => AbsValue::bool_true(),
+                            AbsNull::Nonnull => AbsValue::bool_false(),
+                            AbsNull::Top => {
+                                return (
+                                    vec![AbsValue::bool_true(), AbsValue::bool_false()],
+                                    vec![(i, arg, AbsNull::null()), (i, arg, AbsNull::nonnull())],
+                                call_kind,
+                                );
+                            }
+                        }
+                    } else {
+                        match (t, f) {
+                            (true, true) => AbsValue::top_bool(),
+                            (true, false) => AbsValue::bool_true(),
+                            (false, true) => AbsValue::bool_false(),
+                            (false, false) => AbsValue::bot(),
+                        }
                     }
                 } else {
                     AbsValue::top_bool()
@@ -683,7 +691,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
             }
             _ => todo!("{}", name),
         };
-        (vec![v], None, call_kind)
+        (vec![v], vec![], call_kind)
     }
 
     fn transfer_rvalue(

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -275,15 +275,16 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
 
         if let Some(nulls) = nulls {
             assert!(new_states.len() == nulls.len());
-            new_states.iter_mut().zip(nulls).for_each(|(state, n)| {
-                match n {
+            new_states
+                .iter_mut()
+                .zip(nulls)
+                .for_each(|(state, n)| match n {
                     AbsNull::Null(i) | AbsNull::Nonnull(i) => {
                         let arg = self.ptr_params_inv.get(&i).unwrap();
                         state.add_null(*arg, n);
                     }
-                    AbsNull::Top => (), // Top is not added to nulls
-                }
-            });
+                    AbsNull::Top => unreachable!(),
+                });
         }
 
         let writes = writess.into_iter().flatten().collect();

--- a/src/ai/test/ptr.rs
+++ b/src/ai/test/ptr.rs
@@ -473,7 +473,7 @@ fn test_is_null_param() {
     ";
     let result = analyze(code);
     assert_eq!(result.len(), 2);
-    assert_eq!(as_int(ret(&result[0])), vec![1]);
+    assert_eq!(as_int(ret(&result[0])), vec![0]);
 }
 
 #[test]


### PR DESCRIPTION
related #13 

변경 사항:
- 함수의 각 parameter에 대해, Top | Null | Nonnull 로 abstraction 
- 함수 분석이 끝나고 각 location에 대해:
  - 만약 어떤 parameter p가 Null인 state만 존재할 경우, 해당 location은 p의 null locations에 포함
  - 만약 어떤 parameter p가 Nonnull인 state만 존재할 경우, 해당 location은 p의 non-null locations에 포함
<br>

[테스트 결과:](https://docs.google.com/spreadsheets/d/1gI9sW0qv8KWRbSOh-ZR2sKZUJqpErBajtP4HHO3Ou5o/edit?usp=sharing)

- glp_read_maxflow: #13 에서 언급한 문제 상황. 다시 추가된 것 확인
- New negatives: 변경 후 추가적으로 삭제된 output parameters. non-null일 때만 갈 수 있는 위치를 추가적으로 탐지하면서 삭제됨. 모두 해당 위치에서 c함수를 호출하거나, intra 함수를 호출하는 케이스 -> FN은 모두 C 함수를 호출하는 케이스

