### PR TITLE
Replace `usize` with more specific types

### DIFF
--- a/src/ai/test/calls.rs
+++ b/src/ai/test/calls.rs
@@ -144,11 +144,11 @@ fn test_write() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![2]);
+    assert_eq!(read_path(&result[0], 0), vec![2]);
 
     assert_eq!(as_int(ret(&result[1])), vec![0]);
     assert_eq!(result[1].writes.len(), 1);
-    assert_eq!(result[1].writes.as_vec()[0].0, vec![2]);
+    assert_eq!(write_path(&result[1], 0), vec![2]);
     assert_eq!(result[1].reads.len(), 0);
 }
 
@@ -172,14 +172,14 @@ fn test_write2() {
 
     assert_eq!(as_int(ret(&result[0])), vec![0]);
     assert_eq!(result[0].writes.len(), 1);
-    assert_eq!(result[0].writes.as_vec()[0].0, vec![1]);
+    assert_eq!(write_path(&result[0], 0), vec![1]);
     assert_eq!(result[0].reads.len(), 0);
 
     assert!(ret(&result[1]).intv.is_top());
     assert_eq!(result[1].writes.len(), 1);
-    assert_eq!(result[1].writes.as_vec()[0].0, vec![2]);
+    assert_eq!(write_path(&result[1], 0), vec![2]);
     assert_eq!(result[1].reads.len(), 1);
-    assert_eq!(result[1].reads.as_vec()[0].0, vec![1]);
+    assert_eq!(read_path(&result[1], 0), vec![1]);
 }
 
 #[test]
@@ -202,7 +202,7 @@ fn test_write_weak() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![2]);
+    assert_eq!(read_path(&result[0], 0), vec![2]);
 }
 
 #[test]
@@ -248,7 +248,7 @@ fn test_read() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![2]);
+    assert_eq!(read_path(&result[0], 0), vec![2]);
 }
 
 #[test]
@@ -273,8 +273,8 @@ fn test_read2() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 2);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![1]);
-    assert_eq!(result[0].reads.as_vec()[1].0, vec![2]);
+    assert_eq!(read_path(&result[0], 0), vec![1]);
+    assert_eq!(read_path(&result[0], 1), vec![2]);
 }
 
 #[test]
@@ -298,8 +298,8 @@ fn test_read_weak() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 2);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![2]);
-    assert_eq!(result[0].reads.as_vec()[1].0, vec![3]);
+    assert_eq!(read_path(&result[0], 0), vec![2]);
+    assert_eq!(read_path(&result[0], 1), vec![3]);
 }
 
 #[test]
@@ -322,11 +322,11 @@ fn test_write_struct() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![2, 0]);
+    assert_eq!(read_path(&result[0], 0), vec![2, 0]);
 
     assert_eq!(as_int(ret(&result[1])), vec![0]);
     assert_eq!(result[1].writes.len(), 1);
-    assert_eq!(result[1].writes.as_vec()[0].0, vec![2, 0]);
+    assert_eq!(write_path(&result[1], 0), vec![2, 0]);
     assert_eq!(result[1].reads.len(), 0);
 }
 
@@ -349,7 +349,7 @@ fn test_write_array() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![2]);
+    assert_eq!(read_path(&result[0], 0), vec![2]);
 }
 
 #[test]

--- a/src/ai/test/labels.rs
+++ b/src/ai/test/labels.rs
@@ -17,7 +17,7 @@ fn test_write_merge() {
 
     assert_eq!(as_int(ret(&result[0])), vec![0, 1]);
     assert_eq!(result[0].writes.len(), 1);
-    assert_eq!(result[0].writes.as_vec()[0].0, vec![2]);
+    assert_eq!(write_path(&result[0], 0), vec![2]);
     assert_eq!(result[0].reads.len(), 0);
 }
 
@@ -37,11 +37,11 @@ fn test_write() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![2]);
+    assert_eq!(read_path(&result[0], 0), vec![2]);
 
     assert_eq!(as_int(ret(&result[1])), vec![0]);
     assert_eq!(result[1].writes.len(), 1);
-    assert_eq!(result[1].writes.as_vec()[0].0, vec![2]);
+    assert_eq!(write_path(&result[1], 0), vec![2]);
     assert_eq!(result[1].reads.len(), 0);
 }
 
@@ -64,11 +64,11 @@ fn test_write_weak() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![3]);
+    assert_eq!(read_path(&result[0], 0), vec![3]);
 
     assert_eq!(as_int(ret(&result[1])), vec![0]);
     assert_eq!(result[1].writes.len(), 1);
-    assert_eq!(result[1].writes.as_vec()[0].0, vec![3]);
+    assert_eq!(write_path(&result[1], 0), vec![3]);
     assert_eq!(result[1].reads.len(), 0);
 }
 
@@ -92,7 +92,7 @@ fn test_read_merge() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![2]);
+    assert_eq!(read_path(&result[0], 0), vec![2]);
 }
 
 #[test]
@@ -112,7 +112,7 @@ fn test_read() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![2]);
+    assert_eq!(read_path(&result[0], 0), vec![2]);
 }
 
 #[test]
@@ -136,8 +136,8 @@ fn test_read_weak() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 2);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![3]);
-    assert_eq!(result[0].reads.as_vec()[1].0, vec![4]);
+    assert_eq!(read_path(&result[0], 0), vec![3]);
+    assert_eq!(read_path(&result[0], 1), vec![4]);
 }
 
 #[test]
@@ -155,7 +155,7 @@ fn test_read_write() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![1]);
+    assert_eq!(read_path(&result[0], 0), vec![1]);
 }
 
 #[test]
@@ -175,12 +175,12 @@ fn test_write2() {
 
     assert_eq!(as_int(ret(&result[0])), vec![0]);
     assert_eq!(result[0].writes.len(), 1);
-    assert_eq!(result[0].writes.as_vec()[0].0, vec![2]);
+    assert_eq!(write_path(&result[0], 0), vec![2]);
     assert_eq!(result[0].reads.len(), 0);
 
     assert_eq!(as_int(ret(&result[1])), vec![0]);
     assert_eq!(result[1].writes.len(), 1);
-    assert_eq!(result[1].writes.as_vec()[0].0, vec![3]);
+    assert_eq!(write_path(&result[1], 0), vec![3]);
     assert_eq!(result[1].reads.len(), 0);
 }
 
@@ -203,8 +203,8 @@ fn test_read2() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 2);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![2]);
-    assert_eq!(result[0].reads.as_vec()[1].0, vec![3]);
+    assert_eq!(read_path(&result[0], 0), vec![2]);
+    assert_eq!(read_path(&result[0], 1), vec![3]);
 }
 
 #[test]
@@ -225,12 +225,12 @@ fn test_write_struct() {
 
     assert_eq!(as_int(ret(&result[0])), vec![0]);
     assert_eq!(result[0].writes.len(), 1);
-    assert_eq!(result[0].writes.as_vec()[0].0, vec![2, 0]);
+    assert_eq!(write_path(&result[0], 0), vec![2, 0]);
     assert_eq!(result[0].reads.len(), 0);
 
     assert_eq!(as_int(ret(&result[1])), vec![0]);
     assert_eq!(result[1].writes.len(), 1);
-    assert_eq!(result[1].writes.as_vec()[0].0, vec![2, 1]);
+    assert_eq!(write_path(&result[1], 0), vec![2, 1]);
     assert_eq!(result[1].reads.len(), 0);
 }
 
@@ -248,8 +248,8 @@ fn test_write_struct_assign() {
 
     assert_eq!(as_int(ret(&result[0])), vec![0]);
     assert_eq!(result[0].writes.len(), 2);
-    assert_eq!(result[0].writes.as_vec()[0].0, vec![1, 0]);
-    assert_eq!(result[0].writes.as_vec()[1].0, vec![1, 1]);
+    assert_eq!(write_path(&result[0], 0), vec![1, 0]);
+    assert_eq!(write_path(&result[0], 1), vec![1, 1]);
     assert_eq!(result[0].reads.len(), 0);
 }
 
@@ -268,9 +268,9 @@ fn test_read_write_struct() {
 
     assert_eq!(as_int(ret(&result[0])), vec![0]);
     assert_eq!(result[0].writes.len(), 1);
-    assert_eq!(result[0].writes.as_vec()[0].0, vec![1, 1]);
+    assert_eq!(write_path(&result[0], 0), vec![1, 1]);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![1, 0]);
+    assert_eq!(read_path(&result[0], 0), vec![1, 0]);
 }
 
 #[test]
@@ -289,9 +289,9 @@ fn test_write_read_struct() {
 
     assert_eq!(as_int(ret(&result[0])), vec![0]);
     assert_eq!(result[0].writes.len(), 1);
-    assert_eq!(result[0].writes.as_vec()[0].0, vec![1, 0]);
+    assert_eq!(write_path(&result[0], 0), vec![1, 0]);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![1, 1]);
+    assert_eq!(read_path(&result[0], 0), vec![1, 1]);
 }
 
 #[test]
@@ -323,7 +323,7 @@ fn test_read_array() {
     assert!(ret(&result[0]).intv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![1]);
+    assert_eq!(read_path(&result[0], 0), vec![1]);
 }
 
 #[test]
@@ -341,10 +341,10 @@ fn test_write_struct2_assign() {
 
     assert_eq!(as_int(ret(&result[0])), vec![0]);
     assert_eq!(result[0].writes.len(), 4);
-    assert_eq!(result[0].writes.as_vec()[0].0, vec![1, 0, 0]);
-    assert_eq!(result[0].writes.as_vec()[1].0, vec![1, 0, 1]);
-    assert_eq!(result[0].writes.as_vec()[2].0, vec![1, 1, 0]);
-    assert_eq!(result[0].writes.as_vec()[3].0, vec![1, 1, 1]);
+    assert_eq!(write_path(&result[0], 0), vec![1, 0, 0]);
+    assert_eq!(write_path(&result[0], 1), vec![1, 0, 1]);
+    assert_eq!(write_path(&result[0], 2), vec![1, 1, 0]);
+    assert_eq!(write_path(&result[0], 3), vec![1, 1, 1]);
     assert_eq!(result[0].reads.len(), 0);
 }
 
@@ -366,11 +366,11 @@ fn test_write_read_write_struct2() {
 
     assert_eq!(as_int(ret(&result[0])), vec![0]);
     assert_eq!(result[0].writes.len(), 3);
-    assert_eq!(result[0].writes.as_vec()[0].0, vec![1, 0, 0]);
-    assert_eq!(result[0].writes.as_vec()[1].0, vec![1, 1, 0]);
-    assert_eq!(result[0].writes.as_vec()[2].0, vec![1, 1, 1]);
+    assert_eq!(write_path(&result[0], 0), vec![1, 0, 0]);
+    assert_eq!(write_path(&result[0], 1), vec![1, 1, 0]);
+    assert_eq!(write_path(&result[0], 2), vec![1, 1, 1]);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![1, 0, 1]);
+    assert_eq!(read_path(&result[0], 0), vec![1, 0, 1]);
 }
 
 #[test]
@@ -393,7 +393,7 @@ fn test_div() {
 
     assert_eq!(as_int(ret(&result[1])), vec![0]);
     assert_eq!(result[1].writes.len(), 1);
-    assert_eq!(result[1].writes.as_vec()[0].0, vec![3]);
+    assert_eq!(write_path(&result[1], 0), vec![3]);
     assert_eq!(result[1].reads.len(), 0);
 }
 
@@ -412,7 +412,7 @@ fn test_unknown_read() {
 
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![1]);
+    assert_eq!(read_path(&result[0], 0), vec![1]);
 }
 
 #[test]
@@ -449,7 +449,7 @@ fn test_recursive() {
     assert_eq!(result.len(), 1);
 
     assert_eq!(result[0].writes.len(), 1);
-    assert_eq!(result[0].writes.as_vec()[0].0, vec![2]);
+    assert_eq!(write_path(&result[0], 0), vec![2]);
     assert_eq!(result[0].reads.len(), 0);
 }
 
@@ -475,7 +475,7 @@ fn test_mutually_recursive() {
     assert_eq!(result.len(), 1);
 
     assert_eq!(result[0].writes.len(), 1);
-    assert_eq!(result[0].writes.as_vec()[0].0, vec![2]);
+    assert_eq!(write_path(&result[0], 0), vec![2]);
     assert_eq!(result[0].reads.len(), 0);
 }
 
@@ -491,7 +491,7 @@ fn test_volatile_write() {
     assert_eq!(result.len(), 1);
 
     assert_eq!(result[0].writes.len(), 1);
-    assert_eq!(result[0].writes.as_vec()[0].0, vec![2]);
+    assert_eq!(write_path(&result[0], 0), vec![2]);
     assert_eq!(result[0].reads.len(), 0);
 }
 
@@ -516,7 +516,7 @@ fn test_bitfields() {
     assert!(ret(&result[0]).uintv.is_top());
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![1, 0]);
+    assert_eq!(read_path(&result[0], 0), vec![1, 0]);
 }
 
 #[test]
@@ -539,5 +539,5 @@ fn test_bitfields_set() {
 
     assert_eq!(result[0].writes.len(), 0);
     assert_eq!(result[0].reads.len(), 1);
-    assert_eq!(result[0].reads.as_vec()[0].0, vec![1, 0]);
+    assert_eq!(read_path(&result[0], 0), vec![1, 0]);
 }

--- a/src/ai/test/mod.rs
+++ b/src/ai/test/mod.rs
@@ -1,4 +1,5 @@
 use rustc_hir::def_id::DefId;
+use rustc_middle::mir::Local;
 
 use super::{analysis, domains::*};
 use crate::*;
@@ -37,7 +38,15 @@ fn analyze(code: &str) -> Vec<AbsState> {
 }
 
 fn ret(st: &AbsState) -> &AbsVal {
-    st.local.get(0)
+    st.local.get(Local::ZERO)
+}
+
+fn read_path(st: &AbsState, i: usize) -> Vec<usize> {
+    st.reads.as_vec()[i].as_vec()
+}
+
+fn write_path(st: &AbsState, i: usize) -> Vec<usize> {
+    st.writes.as_vec()[i].as_vec()
 }
 
 fn as_int(v: &AbsVal) -> Vec<i128> {


### PR DESCRIPTION
`usize` 타입이 다양한 의미로 사용되어 코드를 이해하기 어려워, 용도에 따라 다음과 같은 타입을 대신 사용하도록 수정했습니다.

* `Loc`: may-points-to analysis에서 각 memory location을 나타내는 index. 원래 있던 `Loc` 타입은 이름을 `ProjectedLoc`으로 바꿈.
* `SccId`: strongly-connected component의 id. may-points-to analysis의 constraint solving에서만 사용.
* `Local`: rustc에서 제공하는 MIR local variable의 타입. `AbsLocal`의 index, one-indexed parameter 등에 사용.
* `FieldIdx`: rustc에서 제공하는 MIR struct field의 타입.
* `ArgIdx`: 포인터 타입 argument의 index. `AbsArgs`와 `AbsNulls`의 index 등에 사용.

위 타입을 사용할 때, 가급적 `Vec`과 `.iter().enumerate()` 대신 `IndexVec`과 `.iter_enumerated()`를 사용하도록 했습니다.

분석 마지막에 output parameter를 찾는 단계에서는 zero-indexed parameter가 사용되는데, 일단 여기는 그대로 `usize`로 두었습니다.

또한, 기존에는 `AbsPath`가 그냥 `Vec<usize>`였는데, 다음과 같이 정의를 수정해 의미를 명확하게 했습니다.

```rust
struct AbsPath {
    base: Local,
    projections: Vec<FieldIdx>,
}
```

이에 따라, 다른 부분은 거의 단순 타입만 대체한 것에 비해, `AbsPath`를 만드는 `expands_path`의 구현이 조금 달라졌습니다.