### PR TITLE
Improve side effect detection

### DIFF
--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -297,7 +297,7 @@ pub fn analyze(
                         body.local_decls.len()
                     );
                 }
-                let debug_f = tcx.def_path_str(*def_id).contains("try_device");
+                let debug_f = tcx.def_path_str(*def_id).contains("_uuconf_ihdb_system_internal");
                 let AnalyzedBody {
                     states,
                     writes_map,
@@ -645,6 +645,7 @@ pub struct Analyzer<'a, 'tcx> {
     pub call_args: BTreeMap<Location, BTreeMap<usize, usize>>,
     pub pre_context: PreAnalysisContext<'a>,
     pub write_locals: BTreeSet<Local>,
+    pub is_merged: bool,
 }
 
 struct AnalyzedBody {
@@ -679,6 +680,7 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
             call_args: BTreeMap::new(),
             pre_context,
             write_locals: BTreeSet::new(),
+            is_merged: false,
         }
     }
 
@@ -1275,6 +1277,9 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
         };
 
         let (states, writes_map, call_info_map) = 'analysis_loop: loop {
+            if !merging_blocks.is_empty() {
+                self.is_merged = true;
+            }
             let mut work_list = WorkList::new(&self.info.rpo_map);
             work_list.push(start_label.clone());
 
@@ -1420,7 +1425,7 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
             writes_map,
             init_state,
             call_info_map,
-            is_merged: !merging_blocks.is_empty(),
+            is_merged: self.is_merged,
         }
     }
 

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -351,7 +351,7 @@ pub fn analyze(
                     .iter()
                     .flat_map(|p| analyzer.expands_path(&AbsPath::new(*p, vec![])))
                     .collect();
-                let exclude_paths: Vec<_> = alias_params
+                let alias_exclude_paths: Vec<_> = alias_params
                     .iter()
                     .flat_map(|p| analyzer.expands_path(&AbsPath::new(*p, vec![])))
                     .collect();
@@ -416,7 +416,7 @@ pub fn analyze(
                     st.writes.remove(&nullable_params);
                     st.writes.remove(&alias_params);
 
-                    st.add_excludes(exclude_paths.iter().cloned());
+                    st.add_excludes(alias_exclude_paths.iter().cloned());
                     st.add_null_excludes(null_exclude_paths.iter().cloned());
 
                     st.null_excludes.remove(&nonnull_params);

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -39,7 +39,7 @@ use super::{
     semantics::{CallKind, TransferedTerminator},
 };
 use crate::{
-    compile_util::{self, body_to_str, LoHi},
+    compile_util::{self, LoHi},
     graph,
     may_analysis::{
         self,
@@ -297,7 +297,6 @@ pub fn analyze(
                         body.local_decls.len()
                     );
                 }
-                let debug_f = tcx.def_path_str(*def_id).contains("_uuconf_ihdb_system_internal");
                 let AnalyzedBody {
                     states,
                     writes_map,
@@ -333,11 +332,6 @@ pub fn analyze(
                     analyzer.get_nullable_candidates(&return_states)
                 };
 
-                if debug_f {
-                    println!("Candidates: {:?}", candidates);
-                    println!("Nonnull Params: {:?}", nonnull_params);
-                }
-
                 let nullable_params = analyzer.find_nullable_params(
                     tcx,
                     &states,
@@ -346,15 +340,6 @@ pub fn analyze(
                     &call_info_map,
                     candidates,
                 );
-
-                if debug_f {
-                    println!("Nullable Params: {:?}", nullable_params);
-                    println!("{}", body_to_str(body));
-                    println!(
-                        "{}",
-                        analysis_result_to_string(body, &states, tcx.sess.source_map()).unwrap()
-                    );
-                }
 
                 let alias_params = if conf.check_global_alias {
                     analyzer.check_reachable_globals(&info_map, &pre_data.globals)

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -722,10 +722,11 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
 
                 // check the writes of callee
                 call_info.iter().all(|kind| match kind {
-                    CallKind::Method | CallKind::RustPure => true,
-                    CallKind::C | CallKind::TOP | CallKind::RustEffect(None) | CallKind::Intra => {
-                        false
-                    }
+                    CallKind::Method | CallKind::RustPure | CallKind::CPure => true,
+                    CallKind::CEffect
+                    | CallKind::TOP
+                    | CallKind::RustEffect(None)
+                    | CallKind::Intra => false,
                     CallKind::RustEffect(Some(bases)) => {
                         bases.iter().all(|p| match p {
                             AbsBase::Local(idx) => {

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -137,7 +137,7 @@ pub struct PreAnalysisContext<'a> {
     pub inv_param: &'a FxHashMap<Loc, FxHashSet<Local>>,
     pub ends: &'a IndexVec<Loc, Loc>,
     pub locals: &'a HybridBitSet<Loc>,
-    pub locals_index: &'a FxHashMap<Loc, Local>,
+    pub index_local_map: &'a FxHashMap<Loc, Local>,
     pub globals: &'a HybridBitSet<Loc>,
     pub solutions: &'a Solutions,
     pub var_nodes: &'a FxHashMap<(LocalDefId, Local), LocNode>,
@@ -150,8 +150,8 @@ impl<'a> PreAnalysisContext<'a> {
             alias: pre_data.aliases.get(&def_id).unwrap(),
             inv_param: pre_data.inv_params.get(&def_id).unwrap(),
             ends: &pre_data.ends,
-            locals: pre_data.locals_map.get(&def_id).unwrap(),
-            locals_index: pre_data.locals_index_map.get(&def_id).unwrap(),
+            locals: pre_data.local_locs.get(&def_id).unwrap(),
+            index_local_map: pre_data.index_locals.get(&def_id).unwrap(),
             globals: &pre_data.non_fn_globals,
             var_nodes: &pre_data.var_nodes,
             solutions,
@@ -764,7 +764,7 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
 
         let mut sol = self.pre_context.solutions[loc].clone();
         sol.intersect(self.pre_context.locals);
-        locals.extend(sol.iter().map(|loc| self.pre_context.locals_index[&loc]));
+        locals.extend(sol.iter().map(|loc| self.pre_context.index_local_map[&loc]));
         true
     }
 
@@ -779,21 +779,20 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
         match &term.kind {
             TerminatorKind::Call { destination, .. } => {
                 let call_info = call_info_map.get(loc).unwrap();
-                // check the destination of call
                 if destination.local == Local::ZERO {
                     return false;
                 }
 
                 let is_indirection = destination.is_indirect_first_projection();
 
-                if destination.local != param
-                    && is_indirection
+                if is_indirection
+                    && destination.local != param
                     && !self.check_indirect_pure(destination.local, local_writes)
                 {
                     return false;
                 }
 
-                if destination.local != param || !is_indirection {
+                if !is_indirection {
                     local_writes.insert(destination.local);
                 }
 
@@ -833,13 +832,13 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
     ) -> bool {
         if let StatementKind::Assign(box (place, _)) = stmt {
             let local = place.local;
-            if local == param {
-                return true;
-            }
             if local == Local::ZERO {
                 return false;
             }
             if place.is_indirect_first_projection() {
+                if local == param {
+                    return true;
+                }
                 return self.check_indirect_pure(local, locals);
             }
 

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -196,6 +196,7 @@ pub fn analyze(
     }
     let (graph, elems) = graph::compute_sccs(&call_graph);
     let inv_graph = graph::inverse(&graph);
+    let transitive = graph::transitive_closure(&call_graph);
     let po: Vec<_> = graph::post_order(&graph, &inv_graph)
         .into_iter()
         .flatten()
@@ -215,7 +216,6 @@ pub fn analyze(
             let loop_blocks = get_loop_blocks(body, &pre_rpo_map);
             let rpo_map = compute_rpo_map(body, &loop_blocks);
             let dead_locals = get_dead_locals(body, tcx);
-            let tran_callees = visit_transitive_callees(*def_id, &call_graph);
             let fn_ptr = visitor.fn_ptrs.contains(def_id);
             global_visitor.visit_body(body);
             let globals = std::mem::take(&mut global_visitor.globals);
@@ -227,7 +227,6 @@ pub fn analyze(
                 dead_locals,
                 fn_ptr,
                 globals,
-                tran_callees,
             };
             (*def_id, info)
         })
@@ -350,7 +349,11 @@ pub fn analyze(
                 );
 
                 let alias_params = if conf.check_global_alias {
-                    analyzer.check_reachable_globals(&info_map, &pre_data.globals)
+                    analyzer.check_reachable_globals(
+                        &info_map,
+                        &pre_data.globals,
+                        transitive.get(def_id).unwrap(),
+                    )
                 } else {
                     BTreeSet::new()
                 };
@@ -607,7 +610,6 @@ struct FuncInfo {
     dead_locals: IndexVec<BasicBlock, DenseBitSet<Local>>,
     fn_ptr: bool,
     globals: FxHashSet<DefId>,
-    tran_callees: FxHashSet<DefId>,
 }
 
 impl FuncInfo {
@@ -978,23 +980,21 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
     ) -> (BTreeSet<Local>, BTreeSet<Local>) {
         let mut candidates = BTreeSet::new();
         let mut nonnull_params = BTreeSet::new();
-        'outer: for i in 1..=(self.info.inputs) {
+        for i in 1..=(self.info.inputs) {
             let l = Local::from_usize(i);
             let Some(arg) = self.ptr_params_inv.get(&l) else {
                 continue;
             };
 
-            for st in return_states.values() {
+            if return_states.values().all(|st| {
                 let writes = st.writes.iter().map(|p| p.base).collect::<FxHashSet<_>>();
-                if (!writes.contains(&l) && st.nulls.is_top(*arg))
+                (!writes.contains(&l) && st.nulls.is_top(*arg))
                     || (writes.contains(&l) && st.nonnulls.contains(l))
-                {
-                    continue;
-                }
+            }) {
+                nonnull_params.insert(l);
+            } else {
                 candidates.insert(l);
-                continue 'outer;
             }
-            nonnull_params.insert(l);
         }
         (candidates, nonnull_params)
     }
@@ -1005,9 +1005,9 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
         &self,
         info_map: &FxHashMap<DefId, FuncInfo>,
         globals: &FxHashMap<LocalDefId, Loc>,
+        callees: &FxHashSet<DefId>,
     ) -> BTreeSet<Local> {
         let mut indexes = FxHashSet::default();
-        let callees = &self.info.tran_callees;
 
         for callee in callees {
             let globals = info_map[callee]
@@ -2026,25 +2026,6 @@ fn expand_projections(
             })
             .collect()
     }
-}
-
-fn visit_transitive_callees(
-    initial_id: DefId,
-    call_graph: &FxHashMap<DefId, FxHashSet<DefId>>,
-) -> FxHashSet<DefId> {
-    let mut visited = FxHashSet::default();
-    let mut stack = vec![initial_id];
-
-    while let Some(callee) = stack.pop() {
-        if !visited.insert(callee) {
-            continue;
-        }
-
-        if let Some(callees) = call_graph.get(&callee) {
-            stack.extend(callees.iter());
-        }
-    }
-    visited
 }
 
 #[allow(unused)]

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -132,14 +132,22 @@ enum Write {
 
 #[derive(Clone, Debug)]
 pub struct PreAnalysisContext<'a> {
-    pub local_def_id: LocalDefId,    // the function being analyzed
-    pub alias: &'a FxHashSet<Local>, // set of parameters that may alias each other
-    pub inv_param: &'a FxHashMap<Loc, FxHashSet<Local>>, /* a location to the set of parameters that may point to it */
-    pub ends: &'a IndexVec<Loc, Loc>,                    // maps global index to its end index
-    pub index_local_map: &'a FxHashMap<Loc, Local>, /* maps a global index to the corresponding local in the function */
-    pub globals: &'a HybridBitSet<Loc>,             // set of global indexes of global variables
-    pub solutions: &'a Solutions,                   // the solutions of the may-points-to analysis
-    pub var_nodes: &'a FxHashMap<(LocalDefId, Local), LocNode>, /* maps (function, local) to the corresponding node */
+    /// the function being analyzed
+    pub local_def_id: LocalDefId,
+    /// set of parameters that may alias each other
+    pub alias: &'a FxHashSet<Local>,
+    /// a location to the set of parameters that may point to it
+    pub inv_param: &'a FxHashMap<Loc, FxHashSet<Local>>,
+    /// maps a Loc to its end Loc
+    pub ends: &'a IndexVec<Loc, Loc>,
+    // maps a Loc to the corresponding local in the function
+    pub index_local_map: &'a FxHashMap<Loc, Local>,
+    /// set of Locs of global variables
+    pub globals: &'a HybridBitSet<Loc>,
+    /// the solutions of the may-points-to analysis
+    pub solutions: &'a Solutions,
+    /// maps (function, local) to the corresponding node
+    pub var_nodes: &'a FxHashMap<(LocalDefId, Local), LocNode>,
 }
 
 impl<'a> PreAnalysisContext<'a> {

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -132,15 +132,14 @@ enum Write {
 
 #[derive(Clone, Debug)]
 pub struct PreAnalysisContext<'a> {
-    pub local_def_id: LocalDefId,
-    pub alias: &'a FxHashSet<Local>,
-    pub inv_param: &'a FxHashMap<Loc, FxHashSet<Local>>,
-    pub ends: &'a IndexVec<Loc, Loc>,
-    pub locals: &'a HybridBitSet<Loc>,
-    pub index_local_map: &'a FxHashMap<Loc, Local>,
-    pub globals: &'a HybridBitSet<Loc>,
-    pub solutions: &'a Solutions,
-    pub var_nodes: &'a FxHashMap<(LocalDefId, Local), LocNode>,
+    pub local_def_id: LocalDefId,    // the function being analyzed
+    pub alias: &'a FxHashSet<Local>, // set of parameters that may alias each other
+    pub inv_param: &'a FxHashMap<Loc, FxHashSet<Local>>, /* a location to the set of parameters that may point to it */
+    pub ends: &'a IndexVec<Loc, Loc>,                    // maps global index to its end index
+    pub index_local_map: &'a FxHashMap<Loc, Local>, /* maps a global index to the corresponding local in the function */
+    pub globals: &'a HybridBitSet<Loc>,             // set of global indexes of global variables
+    pub solutions: &'a Solutions,                   // the solutions of the may-points-to analysis
+    pub var_nodes: &'a FxHashMap<(LocalDefId, Local), LocNode>, /* maps (function, local) to the corresponding node */
 }
 
 impl<'a> PreAnalysisContext<'a> {
@@ -150,7 +149,6 @@ impl<'a> PreAnalysisContext<'a> {
             alias: pre_data.aliases.get(&def_id).unwrap(),
             inv_param: pre_data.inv_params.get(&def_id).unwrap(),
             ends: &pre_data.ends,
-            locals: pre_data.local_locs.get(&def_id).unwrap(),
             index_local_map: pre_data.index_locals.get(&def_id).unwrap(),
             globals: &pre_data.non_fn_globals,
             var_nodes: &pre_data.var_nodes,
@@ -196,7 +194,7 @@ pub fn analyze(
     }
     let (graph, elems) = graph::compute_sccs(&call_graph);
     let inv_graph = graph::inverse(&graph);
-    let transitive = graph::transitive_closure(&call_graph);
+    let transitive = graph::reflexive_transitive_closure(&call_graph);
     let po: Vec<_> = graph::post_order(&graph, &inv_graph)
         .into_iter()
         .flatten()
@@ -638,7 +636,7 @@ pub struct Analyzer<'a, 'tcx> {
     pub ptr_params_inv: FxHashMap<Local, ArgIdx>,
     pub call_args: BTreeMap<Location, BTreeMap<usize, usize>>,
     pub pre_context: PreAnalysisContext<'a>,
-    pub write_locals: BTreeSet<Local>,
+    pub indirect_assigns: BTreeSet<Local>,
     pub is_merged: bool,
 }
 
@@ -673,7 +671,7 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
             ptr_params_inv: FxHashMap::default(),
             call_args: BTreeMap::new(),
             pre_context,
-            write_locals: BTreeSet::new(),
+            indirect_assigns: BTreeSet::new(),
             is_merged: false,
         }
     }
@@ -758,13 +756,15 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
         let var_nodes = self.pre_context.var_nodes;
         let loc = var_nodes[&(self.pre_context.local_def_id, local)].index;
 
-        if self.check_may_points_global(std::iter::once(loc)) {
+        if self.check_may_points_global(loc) {
             return false;
         }
 
-        let mut sol = self.pre_context.solutions[loc].clone();
-        sol.intersect(self.pre_context.locals);
-        local_writes.extend(sol.iter().map(|loc| self.pre_context.index_local_map[&loc]));
+        let sol = self.pre_context.solutions[loc].clone();
+        local_writes.extend(
+            sol.iter()
+                .flat_map(|loc| self.pre_context.index_local_map.get(&loc)),
+        );
         true
     }
 
@@ -1004,12 +1004,12 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
         &self,
         info_map: &FxHashMap<DefId, FuncInfo>,
         globals: &FxHashMap<LocalDefId, Loc>,
-        callees: &FxHashSet<DefId>,
+        reachables: &FxHashSet<DefId>,
     ) -> BTreeSet<Local> {
         let mut indexes = FxHashSet::default();
 
-        for callee in callees {
-            let globals = info_map[callee]
+        for reachable in reachables {
+            let globals = info_map[reachable]
                 .globals
                 .iter()
                 .filter_map(|def_id| {
@@ -1028,24 +1028,23 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
             .collect()
     }
 
-    fn check_may_points_global<I: Iterator<Item = Loc>>(&self, locs: I) -> bool {
-        for loc in locs {
-            let mut sol = self.pre_context.solutions[loc].clone();
-            sol.intersect(self.pre_context.globals);
+    fn check_may_points_global(&self, loc: Loc) -> bool {
+        let mut sol = self.pre_context.solutions[loc].clone();
+        sol.intersect(self.pre_context.globals);
 
-            if !sol.is_empty() {
-                return true;
-            }
+        if !sol.is_empty() {
+            return true;
         }
         false
     }
 
     fn check_global_writes(&self) -> bool {
-        self.write_locals.iter().any(|local| {
+        self.indirect_assigns.iter().any(|local| {
             let var_nodes = self.pre_context.var_nodes;
+            // We only check start since the local is a pointer
+            // If the local is the first parameter of the function, ends[loc] may not be the same as start
             let start = var_nodes[&(self.pre_context.local_def_id, *local)].index;
-            let end = self.pre_context.ends[start];
-            self.check_may_points_global(start..=end)
+            self.check_may_points_global(start)
         })
     }
 

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -319,7 +319,7 @@ pub fn analyze(
                     .cloned()
                     .unwrap_or_default();
 
-                // If there is a merged block, always check if every parameter is nullable
+                // If there is a merged block, always check all parameters
                 let (candidates, nonnull_params) = if is_merged {
                     (
                         (1..=(analyzer.info.inputs))

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -754,7 +754,7 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
         true
     }
 
-    fn check_indirect_pure(&self, local: Local, locals: &mut BTreeSet<Local>) -> bool {
+    fn check_indirect_pure(&self, local: Local, local_writes: &mut BTreeSet<Local>) -> bool {
         let var_nodes = self.pre_context.var_nodes;
         let loc = var_nodes[&(self.pre_context.local_def_id, local)].index;
 
@@ -764,7 +764,7 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
 
         let mut sol = self.pre_context.solutions[loc].clone();
         sol.intersect(self.pre_context.locals);
-        locals.extend(sol.iter().map(|loc| self.pre_context.index_local_map[&loc]));
+        local_writes.extend(sol.iter().map(|loc| self.pre_context.index_local_map[&loc]));
         true
     }
 
@@ -826,7 +826,7 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
 
     fn check_assign_pure(
         &self,
-        locals: &mut BTreeSet<Local>,
+        local_writes: &mut BTreeSet<Local>,
         param: Local,
         stmt: &StatementKind<'_>,
     ) -> bool {
@@ -839,10 +839,10 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
                 if local == param {
                     return true;
                 }
-                return self.check_indirect_pure(local, locals);
+                return self.check_indirect_pure(local, local_writes);
             }
 
-            locals.insert(place.local);
+            local_writes.insert(place.local);
             true
         } else {
             unreachable!("{:?}", stmt)

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -134,12 +134,12 @@ enum Write {
 pub struct PreAnalysisContext<'a> {
     pub local_def_id: LocalDefId,    // the function being analyzed
     pub alias: &'a FxHashSet<Local>, // set of parameters that may alias each other
-    pub inv_param: &'a FxHashMap<Loc, FxHashSet<Local>>, // a location to the set of parameters that may point to it
+    pub inv_param: &'a FxHashMap<Loc, FxHashSet<Local>>, /* a location to the set of parameters that may point to it */
     pub ends: &'a IndexVec<Loc, Loc>,                    // maps global index to its end index
-    pub index_local_map: &'a FxHashMap<Loc, Local>, // maps a global index to the corresponding local in the function
+    pub index_local_map: &'a FxHashMap<Loc, Local>, /* maps a global index to the corresponding local in the function */
     pub globals: &'a HybridBitSet<Loc>,             // set of global indexes of global variables
     pub solutions: &'a Solutions,                   // the solutions of the may-points-to analysis
-    pub var_nodes: &'a FxHashMap<(LocalDefId, Local), LocNode>, // maps (function, local) to the corresponding node
+    pub var_nodes: &'a FxHashMap<(LocalDefId, Local), LocNode>, /* maps (function, local) to the corresponding node */
 }
 
 impl<'a> PreAnalysisContext<'a> {

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -136,17 +136,25 @@ pub struct PreAnalysisContext<'a> {
     pub alias: &'a FxHashSet<Local>,
     pub inv_param: &'a FxHashMap<Loc, FxHashSet<Local>>,
     pub ends: &'a IndexVec<Loc, Loc>,
+    pub locals: &'a HybridBitSet<Loc>,
+    pub locals_index: &'a FxHashMap<Loc, Local>,
     pub globals: &'a HybridBitSet<Loc>,
+    pub solutions: &'a Solutions,
+    pub var_nodes: &'a FxHashMap<(LocalDefId, Local), LocNode>,
 }
 
 impl<'a> PreAnalysisContext<'a> {
-    fn new(def_id: DefId, pre_data: &'a AliasResults) -> Self {
+    fn new(def_id: DefId, pre_data: &'a AliasResults, solutions: &'a Solutions) -> Self {
         Self {
             local_def_id: def_id.as_local().unwrap(),
             alias: pre_data.aliases.get(&def_id).unwrap(),
             inv_param: pre_data.inv_params.get(&def_id).unwrap(),
             ends: &pre_data.ends,
+            locals: pre_data.locals_map.get(&def_id).unwrap(),
+            locals_index: pre_data.locals_index_map.get(&def_id).unwrap(),
             globals: &pre_data.non_fn_globals,
+            var_nodes: &pre_data.var_nodes,
+            solutions,
         }
     }
 
@@ -284,7 +292,7 @@ pub fn analyze(
             for def_id in def_ids {
                 let start = std::time::Instant::now();
 
-                let pre_context = PreAnalysisContext::new(*def_id, &pre_data);
+                let pre_context = PreAnalysisContext::new(*def_id, &pre_data, &solutions);
 
                 let mut analyzer =
                     Analyzer::new(tcx, &info_map[def_id], conf, &summaries, pre_context);
@@ -432,8 +440,7 @@ pub fn analyze(
                     )
                 });
 
-                has_side_effects = has_side_effects
-                    || analyzer.check_global_writes(&solutions, &pre_data.var_nodes);
+                has_side_effects = has_side_effects || analyzer.check_global_writes();
 
                 let summary = FunctionSummary::new(init_state, return_states, has_side_effects);
                 results.insert(*def_id, states);
@@ -457,7 +464,7 @@ pub fn analyze(
 
             if !need_rerun {
                 for def_id in def_ids {
-                    let pre_context = PreAnalysisContext::new(*def_id, &pre_data);
+                    let pre_context = PreAnalysisContext::new(*def_id, &pre_data, &solutions);
                     let mut analyzer =
                         Analyzer::new(tcx, &info_map[def_id], conf, &summaries, pre_context);
                     analyzer.ptr_params = ptr_params_map.remove(def_id).unwrap();
@@ -745,6 +752,20 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
         true
     }
 
+    fn check_indirect_pure(&self, local: Local, locals: &mut BTreeSet<Local>) -> bool {
+        let var_nodes = self.pre_context.var_nodes;
+        let loc = var_nodes[&(self.pre_context.local_def_id, local)].index;
+
+        if self.check_may_points_global(std::iter::once(loc)) {
+            return false;
+        }
+
+        let mut sol = self.pre_context.solutions[loc].clone();
+        sol.intersect(self.pre_context.locals);
+        locals.extend(sol.iter().map(|loc| self.pre_context.locals_index[&loc]));
+        true
+    }
+
     fn check_terminator_pure(
         &self,
         loc: &Location,
@@ -760,7 +781,17 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
                 if destination.local == Local::ZERO {
                     return false;
                 }
-                if destination.local != param || !destination.is_indirect_first_projection() {
+
+                let is_indirection = destination.is_indirect_first_projection();
+
+                if destination.local != param
+                    && is_indirection
+                    && !self.check_indirect_pure(destination.local, local_writes)
+                {
+                    return false;
+                }
+
+                if destination.local != param || !is_indirection {
                     local_writes.insert(destination.local);
                 }
 
@@ -794,18 +825,23 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
 
     fn check_assign_pure(
         &self,
-        locs: &mut BTreeSet<Local>,
+        locals: &mut BTreeSet<Local>,
         param: Local,
         stmt: &StatementKind<'_>,
     ) -> bool {
         if let StatementKind::Assign(box (place, _)) = stmt {
-            if place.local == param && place.is_indirect_first_projection() {
+            let local = place.local;
+            if local == param {
                 return true;
             }
-            if place.local == Local::ZERO {
+            if local == Local::ZERO {
                 return false;
             }
-            locs.insert(place.local);
+            if place.is_indirect_first_projection() {
+                return self.check_indirect_pure(local, locals);
+            }
+
+            locals.insert(place.local);
             true
         } else {
             unreachable!("{:?}", stmt)
@@ -993,23 +1029,25 @@ impl<'a, 'tcx> Analyzer<'a, 'tcx> {
             .collect()
     }
 
-    fn check_global_writes(
-        &self,
-        solutions: &Solutions,
-        var_nodes: &FxHashMap<(LocalDefId, Local), LocNode>,
-    ) -> bool {
-        self.write_locals
-            .iter()
-            .flat_map(|local| {
-                let start = var_nodes[&(self.pre_context.local_def_id, *local)].index;
-                let end = self.pre_context.ends[start];
-                start..=end
-            })
-            .any(|loc| {
-                let mut sol = solutions[loc].clone();
-                sol.intersect(self.pre_context.globals);
-                !sol.is_empty()
-            })
+    fn check_may_points_global<I: Iterator<Item = Loc>>(&self, locs: I) -> bool {
+        for loc in locs {
+            let mut sol = self.pre_context.solutions[loc].clone();
+            sol.intersect(self.pre_context.globals);
+
+            if !sol.is_empty() {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn check_global_writes(&self) -> bool {
+        self.write_locals.iter().any(|local| {
+            let var_nodes = self.pre_context.var_nodes;
+            let start = var_nodes[&(self.pre_context.local_def_id, *local)].index;
+            let end = self.pre_context.ends[start];
+            self.check_may_points_global(start..=end)
+        })
     }
 
     fn find_output_params(

--- a/src/ai/analysis.rs
+++ b/src/ai/analysis.rs
@@ -134,12 +134,12 @@ enum Write {
 pub struct PreAnalysisContext<'a> {
     pub local_def_id: LocalDefId,    // the function being analyzed
     pub alias: &'a FxHashSet<Local>, // set of parameters that may alias each other
-    pub inv_param: &'a FxHashMap<Loc, FxHashSet<Local>>, /* a location to the set of parameters that may point to it */
+    pub inv_param: &'a FxHashMap<Loc, FxHashSet<Local>>, // a location to the set of parameters that may point to it
     pub ends: &'a IndexVec<Loc, Loc>,                    // maps global index to its end index
-    pub index_local_map: &'a FxHashMap<Loc, Local>, /* maps a global index to the corresponding local in the function */
+    pub index_local_map: &'a FxHashMap<Loc, Local>, // maps a global index to the corresponding local in the function
     pub globals: &'a HybridBitSet<Loc>,             // set of global indexes of global variables
     pub solutions: &'a Solutions,                   // the solutions of the may-points-to analysis
-    pub var_nodes: &'a FxHashMap<(LocalDefId, Local), LocNode>, /* maps (function, local) to the corresponding node */
+    pub var_nodes: &'a FxHashMap<(LocalDefId, Local), LocNode>, // maps (function, local) to the corresponding node
 }
 
 impl<'a> PreAnalysisContext<'a> {

--- a/src/ai/domains.rs
+++ b/src/ai/domains.rs
@@ -6,7 +6,7 @@ use std::{
 
 use lazy_static::lazy_static;
 use rustc_abi::FieldIdx;
-use rustc_hash::{FxHashSet, FxHashMap};
+use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_index::{bit_set::DenseBitSet, IndexVec};
 use rustc_middle::mir::Local;
 use rustc_span::def_id::DefId;
@@ -103,7 +103,11 @@ impl AbsState {
         }
     }
 
-    pub fn add_writes<I: Iterator<Item = AbsPath>>(&mut self, paths: I, ptr_params_inv: &FxHashMap<Local, ArgIdx>) -> BTreeSet<AbsPath> {
+    pub fn add_writes<I: Iterator<Item = AbsPath>>(
+        &mut self,
+        paths: I,
+        ptr_params_inv: &FxHashMap<Local, ArgIdx>,
+    ) -> BTreeSet<AbsPath> {
         let mut res = BTreeSet::new();
         let locals = self.writes.iter().map(|p| p.base).collect::<FxHashSet<_>>();
         for path in paths {

--- a/src/ai/domains.rs
+++ b/src/ai/domains.rs
@@ -121,7 +121,7 @@ impl AbsState {
     ) -> (BTreeSet<AbsPath>, BTreeSet<Local>) {
         let mut res = BTreeSet::new();
         let mut nonnull_cands = BTreeSet::new();
-        let locals = self.writes.iter().map(|p| p.base).collect::<FxHashSet<_>>();
+        let mut locals = self.writes.iter().map(|p| p.base).collect::<FxHashSet<_>>();
 
         for path in paths {
             if !self.reads.contains(&path) && !self.excludes.contains(&path) {
@@ -129,6 +129,7 @@ impl AbsState {
                 let arg = ptr_params_inv.get(&l).unwrap();
                 if !locals.contains(&l) && self.nulls.is_top(*arg) {
                     nonnull_cands.insert(l);
+                    locals.insert(l);
                 }
                 self.writes.insert(path.clone());
                 res.insert(path);

--- a/src/ai/domains.rs
+++ b/src/ai/domains.rs
@@ -17,6 +17,7 @@ pub struct AbsState {
     pub local: AbsLocal,
     pub args: AbsArgs,
     pub excludes: MayPathSet,
+    pub null_excludes: MayPathSet,
     pub reads: MayPathSet,
     pub writes: MustPathSet,
     pub nulls: AbsNulls,
@@ -30,6 +31,7 @@ impl AbsState {
             local: AbsLocal::bot(),
             args: AbsArgs::bot(),
             excludes: MayPathSet::bot(),
+            null_excludes: MayPathSet::bot(),
             reads: MayPathSet::bot(),
             writes: MustPathSet::bot(),
             nulls: AbsNulls::bot(),
@@ -42,6 +44,7 @@ impl AbsState {
             local: self.local.join(&other.local),
             args: self.args.join(&other.args),
             excludes: self.excludes.join(&other.excludes),
+            null_excludes: self.null_excludes.join(&other.null_excludes),
             reads: self.reads.join(&other.reads),
             writes: self.writes.join(&other.writes),
             nulls: self.nulls.join(&other.nulls),
@@ -54,6 +57,7 @@ impl AbsState {
             local: self.local.widen(&other.local),
             args: self.args.widen(&other.args),
             excludes: self.excludes.widen(&other.excludes),
+            null_excludes: self.null_excludes.widen(&other.null_excludes),
             reads: self.reads.widen(&other.reads),
             writes: self.writes.widen(&other.writes),
             nulls: self.nulls.widen(&other.nulls),
@@ -65,6 +69,7 @@ impl AbsState {
         self.local.ord(&other.local)
             && self.args.ord(&other.args)
             && self.excludes.ord(&other.excludes)
+            && self.null_excludes.ord(&other.null_excludes)
             && self.reads.ord(&other.reads)
             && self.writes.ord(&other.writes)
             && self.nulls.ord(&other.nulls)
@@ -92,6 +97,12 @@ impl AbsState {
     pub fn add_excludes<I: Iterator<Item = AbsPath>>(&mut self, paths: I) {
         for path in paths {
             self.excludes.insert(path);
+        }
+    }
+
+    pub fn add_null_excludes<I: Iterator<Item = AbsPath>>(&mut self, paths: I) {
+        for path in paths {
+            self.null_excludes.insert(path);
         }
     }
 
@@ -3233,6 +3244,11 @@ impl MayPathSet {
     #[inline]
     pub fn insert(&mut self, place: AbsPath) {
         self.0.insert(place);
+    }
+
+    #[inline]
+    pub fn remove(&mut self, base: &BTreeSet<Local>) {
+        self.0.retain(|p| !base.contains(&p.base));
     }
 
     #[inline]

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -80,7 +80,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
             let (mut new_state, writes) = self.assign(place, new_v, state);
             new_state.add_excludes(cmps.into_iter());
             new_state.add_reads(reads.into_iter());
-            let writes = new_state.add_writes(writes.into_iter());
+            let writes = new_state.add_writes(writes.into_iter(), &self.ptr_params_inv);
             (new_state, writes)
         } else {
             (state.clone(), BTreeSet::new())
@@ -186,7 +186,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                         .flat_map(|arg| self.get_read_paths_of_ptr(&arg.ptrv, &[]));
                     reads.extend(reads2);
                     new_state.add_reads(reads.into_iter());
-                    let writes = new_state.add_writes(writes.into_iter());
+                    let writes = new_state.add_writes(writes.into_iter(), &self.ptr_params_inv);
                     for arg in &args {
                         self.indirect_assign(&arg.ptrv, &AbsValue::top(), &[], &mut new_state);
                     }
@@ -266,7 +266,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                 let (mut new_state, writes_ret) = self.assign(dst, v, &state);
                 new_state.add_excludes(offsets.iter().cloned());
                 new_state.add_reads(reads.iter().cloned());
-                let writes = new_state.add_writes(writes.iter().cloned().chain(writes_ret));
+                let writes = new_state.add_writes(writes.iter().cloned().chain(writes_ret), &self.ptr_params_inv);
                 (new_state, writes)
             })
             .unzip();
@@ -368,7 +368,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
             state.add_excludes(callee_excludes.into_iter());
             state.add_reads(reads.clone().into_iter());
             state.add_reads(callee_reads.into_iter());
-            let writes = state.add_writes(callee_writes.into_iter().chain(writes));
+            let writes = state.add_writes(callee_writes.into_iter().chain(writes), &self.ptr_params_inv);
             ret_writes.extend(writes);
             states.push(state)
         }

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -266,7 +266,10 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                 let (mut new_state, writes_ret) = self.assign(dst, v, &state);
                 new_state.add_excludes(offsets.iter().cloned());
                 new_state.add_reads(reads.iter().cloned());
-                let writes = new_state.add_writes(writes.iter().cloned().chain(writes_ret), &self.ptr_params_inv);
+                let writes = new_state.add_writes(
+                    writes.iter().cloned().chain(writes_ret),
+                    &self.ptr_params_inv,
+                );
                 (new_state, writes)
             })
             .unzip();
@@ -368,7 +371,10 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
             state.add_excludes(callee_excludes.into_iter());
             state.add_reads(reads.clone().into_iter());
             state.add_reads(callee_reads.into_iter());
-            let writes = state.add_writes(callee_writes.into_iter().chain(writes), &self.ptr_params_inv);
+            let writes = state.add_writes(
+                callee_writes.into_iter().chain(writes),
+                &self.ptr_params_inv,
+            );
             ret_writes.extend(writes);
             states.push(state)
         }

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -436,12 +436,11 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
         let name = self.def_id_to_string(callee);
         let mut segs: Vec<_> = name.split("::").collect();
         let segs0 = segs.pop().unwrap_or_default();
-        // let segs1 = segs.pop().unwrap_or_default();
-        // let segs2 = segs.pop().unwrap_or_default();
-        // let segs3 = segs.pop().unwrap_or_default();
 
         let call_kind = match segs0 {
             "__ctype_toupper_loc"
+            | "towlower"
+            | "towupper"
             | "gettimeofday"
             | "strlen"
             | "strspn"

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -336,6 +336,11 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
             }
             let ret_v = ret_v.subst(&ptr_maps);
             let (mut state, writes) = self.assign(dst, ret_v, &state);
+            let callee_null_excludes: Vec<_> = return_state
+                .null_excludes
+                .iter()
+                .flat_map(|exclude| self.get_caller_path(exclude, args))
+                .collect();
             let callee_excludes: Vec<_> = return_state
                 .excludes
                 .iter()
@@ -369,6 +374,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                     .insert(path.base.index() - 1, idx);
             }
             state.add_excludes(callee_excludes.into_iter());
+            state.add_null_excludes(callee_null_excludes.into_iter());
             state.add_reads(reads.clone().into_iter());
             state.add_reads(callee_reads.into_iter());
             let writes = state.add_writes(

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -377,8 +377,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
                 if array_access {
                     continue;
                 }
-                let local: Local = Local::from_usize(write.base.index());
-                if return_state.nonnulls.contains(local) {
+                if return_state.nonnulls.contains(write.base) {
                     callee_nonnulls.insert(path.base);
                 }
 

--- a/src/ai/semantics.rs
+++ b/src/ai/semantics.rs
@@ -1231,7 +1231,7 @@ impl<'tcx> super::analysis::Analyzer<'_, 'tcx> {
         let writes = if place.is_indirect_first_projection() {
             let projection = self.abstract_projection(&place.projection[1..], state);
             let ptr = state.local.get(place.local);
-            self.write_locals.insert(place.local);
+            self.indirect_assigns.insert(place.local);
             self.indirect_assign(&ptr.ptrv, &new_v, &projection, &mut new_state);
             self.get_write_paths_of_ptr(&ptr.ptrv, &projection)
         } else {

--- a/src/ai/test/ptr.rs
+++ b/src/ai/test/ptr.rs
@@ -544,7 +544,7 @@ fn test_nullable_effect_call2() {
     ";
     let result = analyze(code);
     assert_eq!(result.len(), 2);
-    assert_eq!(result[1].excludes.len(), 1);
+    assert_eq!(result[1].excludes.len(), 0);
 }
 
 #[test]

--- a/src/ai/test/ptr.rs
+++ b/src/ai/test/ptr.rs
@@ -487,7 +487,7 @@ fn test_nullable_empty() {
     let result = analyze(code);
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].writes.len(), 1);
-    assert_eq!(result[0].excludes.len(), 0);
+    assert_eq!(result[0].null_excludes.len(), 0);
 }
 
 #[test]
@@ -503,9 +503,9 @@ fn test_nullable_write() {
     let result = analyze(code);
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].writes.len(), 0);
-    assert_eq!(result[0].excludes.len(), 0);
+    assert_eq!(result[0].null_excludes.len(), 0);
     assert_eq!(result[1].writes.len(), 1);
-    assert_eq!(result[0].excludes.len(), 0);
+    assert_eq!(result[0].null_excludes.len(), 0);
 }
 
 #[test]
@@ -524,8 +524,9 @@ fn test_nullable_effect_call1() {
         }
     ";
     let result = analyze(code);
+    println!("{:?}", result);
     assert_eq!(result.len(), 2);
-    assert_eq!(result[1].excludes.len(), 1);
+    assert_eq!(result[1].null_excludes.len(), 1);
 }
 
 #[test]
@@ -544,7 +545,7 @@ fn test_nullable_effect_call2() {
     ";
     let result = analyze(code);
     assert_eq!(result.len(), 2);
-    assert_eq!(result[1].excludes.len(), 0);
+    assert_eq!(result[1].null_excludes.len(), 0);
 }
 
 #[test]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -53,6 +53,16 @@ pub fn transitive_closure<T: Clone + Eq + std::hash::Hash>(
     new_graph
 }
 
+pub fn reflexive_transitive_closure<T: Clone + Eq + std::hash::Hash>(
+    graph: &FxHashMap<T, FxHashSet<T>>,
+) -> FxHashMap<T, FxHashSet<T>> {
+    let mut new_graph = transitive_closure(graph);
+    for v in graph.keys() {
+        new_graph.get_mut(v).unwrap().insert(v.clone());
+    }
+    new_graph
+}
+
 pub fn reachable_vertices<T: Idx + std::hash::Hash>(
     graph: &FxHashMap<T, FxHashSet<T>>,
     source: T,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2,15 +2,27 @@ use rustc_data_structures::graph::{scc::Sccs, vec_graph::VecGraph};
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_index::Idx;
 
-pub fn transitive_closure<T: Idx + std::hash::Hash>(
+pub fn transitive_closure<T: Clone + Eq + std::hash::Hash>(
     graph: &FxHashMap<T, FxHashSet<T>>,
 ) -> FxHashMap<T, FxHashSet<T>> {
-    let len = graph.len();
+    for succs in graph.values() {
+        for succ in succs {
+            assert!(graph.contains_key(succ));
+        }
+    }
+    let id_to_v: Vec<_> = graph.keys().cloned().collect();
+    let v_to_id: FxHashMap<_, _> = id_to_v
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(k, v)| (v, k))
+        .collect();
+    let len = id_to_v.len();
 
     let mut reachability = vec![vec![false; len]; len];
     for (v, succs) in graph.iter() {
         for succ in succs {
-            reachability[v.index()][succ.index()] = true;
+            reachability[v_to_id[v]][v_to_id[succ]] = true;
         }
     }
 
@@ -30,13 +42,13 @@ pub fn transitive_closure<T: Idx + std::hash::Hash>(
             .enumerate()
             .filter_map(|(to, is_reachable)| {
                 if *is_reachable {
-                    Some(T::new(to))
+                    Some(id_to_v[to].clone())
                 } else {
                     None
                 }
             })
             .collect();
-        new_graph.insert(T::new(i), neighbors);
+        new_graph.insert(id_to_v[i].clone(), neighbors);
     }
     new_graph
 }

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -133,6 +133,7 @@ pub struct AliasResults {
     pub ends: IndexVec<Loc, Loc>,
     pub globals: FxHashMap<LocalDefId, Loc>,
     pub non_fn_globals: HybridBitSet<Loc>,
+    pub var_nodes: FxHashMap<(LocalDefId, Local), LocNode>,
 }
 
 #[derive(Debug)]
@@ -560,7 +561,7 @@ fn collect_param_alias<'tcx>(
 // Computes the aliasing information for the function parameters
 pub fn compute_alias<'tcx>(
     pre: PreAnalysisData<'tcx>,
-    solutions: Solutions,
+    solutions: &Solutions,
     inputs_map: &FxHashMap<DefId, usize>,
     tcx: TyCtxt<'tcx>,
     check_global_alias: bool,
@@ -642,6 +643,7 @@ pub fn compute_alias<'tcx>(
         ends: pre.index_info.ends,
         globals: pre.globals,
         non_fn_globals,
+        var_nodes: pre.var_nodes,
     }
 }
 

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -607,15 +607,7 @@ pub fn compute_alias<'tcx>(
                 if fun_alias.len() == params.len() {
                     break;
                 }
-                collect_param_alias(
-                    &pre,
-                    solutions,
-                    &locals,
-                    args,
-                    &params,
-                    &mut fun_alias,
-                    tcx,
-                )
+                collect_param_alias(&pre, solutions, &locals, args, &params, &mut fun_alias, tcx)
             }
         }
 

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -609,7 +609,7 @@ pub fn compute_alias<'tcx>(
                 }
                 collect_param_alias(
                     &pre,
-                    &solutions,
+                    solutions,
                     &locals,
                     args,
                     &params,

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -129,12 +129,12 @@ pub type Solutions = IndexVec<Loc, HybridBitSet<Loc>>; // Send not implemented f
 #[derive(Debug)]
 pub struct AliasResults {
     pub aliases: FxHashMap<DefId, FxHashSet<Local>>, // set of parameters that may alias each other
-    pub inv_params: FxHashMap<DefId, FxHashMap<Loc, FxHashSet<Local>>>, // maps a location to the set of parameters that may point to it
+    pub inv_params: FxHashMap<DefId, FxHashMap<Loc, FxHashSet<Local>>>, /* maps a location to the set of parameters that may point to it */
     pub ends: IndexVec<Loc, Loc>, // maps global index to its end index
     pub globals: FxHashMap<LocalDefId, Loc>, // maps a static item to the corresponding global index
-    pub var_nodes: FxHashMap<(LocalDefId, Local), LocNode>, // maps (function, local) to the corresponding node
+    pub var_nodes: FxHashMap<(LocalDefId, Local), LocNode>, /* maps (function, local) to the corresponding node */
     pub non_fn_globals: HybridBitSet<Loc>, // set of global indexes of global variables
-    pub index_locals: FxHashMap<DefId, FxHashMap<Loc, Local>>, // maps a global index to the corresponding local
+    pub index_locals: FxHashMap<DefId, FxHashMap<Loc, Local>>, /* maps a global index to the corresponding local */
 }
 
 #[derive(Debug)]

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -128,13 +128,20 @@ pub type Solutions = IndexVec<Loc, HybridBitSet<Loc>>; // Send not implemented f
 
 #[derive(Debug)]
 pub struct AliasResults {
-    pub aliases: FxHashMap<DefId, FxHashSet<Local>>, // set of parameters that may alias each other
-    pub inv_params: FxHashMap<DefId, FxHashMap<Loc, FxHashSet<Local>>>, /* maps a location to the set of parameters that may point to it */
-    pub ends: IndexVec<Loc, Loc>, // maps global index to its end index
-    pub globals: FxHashMap<LocalDefId, Loc>, // maps a static item to the corresponding global index
-    pub var_nodes: FxHashMap<(LocalDefId, Local), LocNode>, /* maps (function, local) to the corresponding node */
-    pub non_fn_globals: HybridBitSet<Loc>, // set of global indexes of global variables
-    pub index_locals: FxHashMap<DefId, FxHashMap<Loc, Local>>, /* maps a global index to the corresponding local */
+    /// set of parameters that may alias each other
+    pub aliases: FxHashMap<DefId, FxHashSet<Local>>,
+    /// maps a location to the set of parameters that may point to it
+    pub inv_params: FxHashMap<DefId, FxHashMap<Loc, FxHashSet<Local>>>,
+    /// maps a Loc to its end Loc
+    pub ends: IndexVec<Loc, Loc>,
+    /// maps a static item to the corresponding Loc
+    pub globals: FxHashMap<LocalDefId, Loc>,
+    /// maps (function, local) to the corresponding node
+    pub var_nodes: FxHashMap<(LocalDefId, Local), LocNode>,
+    /// set of Locs of global variables
+    pub non_fn_globals: HybridBitSet<Loc>,
+    /// maps a Loc to the corresponding local
+    pub index_locals: FxHashMap<DefId, FxHashMap<Loc, Local>>,
 }
 
 #[derive(Debug)]

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -134,8 +134,8 @@ pub struct AliasResults {
     pub globals: FxHashMap<LocalDefId, Loc>,
     pub var_nodes: FxHashMap<(LocalDefId, Local), LocNode>,
     pub non_fn_globals: HybridBitSet<Loc>,
-    pub locals_map: FxHashMap<DefId, HybridBitSet<Loc>>,
-    pub locals_index_map: FxHashMap<DefId, FxHashMap<Loc, Local>>,
+    pub local_locs: FxHashMap<DefId, HybridBitSet<Loc>>,
+    pub index_locals: FxHashMap<DefId, FxHashMap<Loc, Local>>,
 }
 
 #[derive(Debug)]
@@ -571,8 +571,8 @@ pub fn compute_alias<'tcx>(
 ) -> AliasResults {
     let mut aliases: FxHashMap<_, FxHashSet<Local>> = FxHashMap::default();
     let mut inv_params: FxHashMap<_, FxHashMap<_, FxHashSet<Local>>> = FxHashMap::default();
-    let mut locals_map: FxHashMap<_, HybridBitSet<Loc>> = FxHashMap::default();
-    let mut locals_index_map: FxHashMap<_, FxHashMap<Loc, Local>> = FxHashMap::default();
+    let mut local_locs: FxHashMap<_, HybridBitSet<Loc>> = FxHashMap::default();
+    let mut index_locals: FxHashMap<_, FxHashMap<Loc, Local>> = FxHashMap::default();
     let non_fn_globals = pre.non_fn_globals.iter().fold(
         HybridBitSet::new_empty(pre.index_info.len()),
         |mut acc, g| {
@@ -634,8 +634,8 @@ pub fn compute_alias<'tcx>(
 
         aliases.insert(*def_id, fun_alias);
         inv_params.insert(*def_id, inv_param);
-        locals_map.insert(*def_id, locals);
-        locals_index_map.insert(*def_id, locals_index);
+        local_locs.insert(*def_id, locals);
+        index_locals.insert(*def_id, locals_index);
     }
 
     AliasResults {
@@ -645,8 +645,8 @@ pub fn compute_alias<'tcx>(
         globals: pre.globals,
         var_nodes: pre.var_nodes,
         non_fn_globals,
-        locals_map,
-        locals_index_map,
+        local_locs,
+        index_locals,
     }
 }
 

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -129,12 +129,12 @@ pub type Solutions = IndexVec<Loc, HybridBitSet<Loc>>; // Send not implemented f
 #[derive(Debug)]
 pub struct AliasResults {
     pub aliases: FxHashMap<DefId, FxHashSet<Local>>, // set of parameters that may alias each other
-    pub inv_params: FxHashMap<DefId, FxHashMap<Loc, FxHashSet<Local>>>, /* maps a location to the set of parameters that may point to it */
+    pub inv_params: FxHashMap<DefId, FxHashMap<Loc, FxHashSet<Local>>>, // maps a location to the set of parameters that may point to it
     pub ends: IndexVec<Loc, Loc>, // maps global index to its end index
     pub globals: FxHashMap<LocalDefId, Loc>, // maps a static item to the corresponding global index
-    pub var_nodes: FxHashMap<(LocalDefId, Local), LocNode>, /* maps (function, local) to the corresponding node */
+    pub var_nodes: FxHashMap<(LocalDefId, Local), LocNode>, // maps (function, local) to the corresponding node
     pub non_fn_globals: HybridBitSet<Loc>, // set of global indexes of global variables
-    pub index_locals: FxHashMap<DefId, FxHashMap<Loc, Local>>, /* maps a global index to the corresponding local */
+    pub index_locals: FxHashMap<DefId, FxHashMap<Loc, Local>>, // maps a global index to the corresponding local
 }
 
 #[derive(Debug)]

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -132,8 +132,10 @@ pub struct AliasResults {
     pub inv_params: FxHashMap<DefId, FxHashMap<Loc, FxHashSet<Local>>>,
     pub ends: IndexVec<Loc, Loc>,
     pub globals: FxHashMap<LocalDefId, Loc>,
-    pub non_fn_globals: HybridBitSet<Loc>,
     pub var_nodes: FxHashMap<(LocalDefId, Local), LocNode>,
+    pub non_fn_globals: HybridBitSet<Loc>,
+    pub locals_map: FxHashMap<DefId, HybridBitSet<Loc>>,
+    pub locals_index_map: FxHashMap<DefId, FxHashMap<Loc, Local>>,
 }
 
 #[derive(Debug)]
@@ -569,6 +571,8 @@ pub fn compute_alias<'tcx>(
 ) -> AliasResults {
     let mut aliases: FxHashMap<_, FxHashSet<Local>> = FxHashMap::default();
     let mut inv_params: FxHashMap<_, FxHashMap<_, FxHashSet<Local>>> = FxHashMap::default();
+    let mut locals_map: FxHashMap<_, HybridBitSet<Loc>> = FxHashMap::default();
+    let mut locals_index_map: FxHashMap<_, FxHashMap<Loc, Local>> = FxHashMap::default();
     let non_fn_globals = pre.non_fn_globals.iter().fold(
         HybridBitSet::new_empty(pre.index_info.len()),
         |mut acc, g| {
@@ -582,6 +586,8 @@ pub fn compute_alias<'tcx>(
         let local_def_id = some_or!(def_id.as_local(), continue);
         let mut params = vec![];
         let mut locals = HybridBitSet::new_empty(pre.index_info.len());
+        let mut locals_index = FxHashMap::default();
+
         // Aliases of the function parameters
         let mut fun_alias = FxHashSet::default();
         // Map of location to set of parameters that may point to the location
@@ -589,6 +595,7 @@ pub fn compute_alias<'tcx>(
 
         for (local, decl) in body.local_decls.iter_enumerated() {
             let g_index = pre.var_nodes[&(local_def_id, local)].index;
+            locals_index.insert(g_index, local);
 
             if (1..=*inputs).contains(&local.index()) {
                 let ty = decl.ty;
@@ -627,6 +634,8 @@ pub fn compute_alias<'tcx>(
 
         aliases.insert(*def_id, fun_alias);
         inv_params.insert(*def_id, inv_param);
+        locals_map.insert(*def_id, locals);
+        locals_index_map.insert(*def_id, locals_index);
     }
 
     AliasResults {
@@ -634,8 +643,10 @@ pub fn compute_alias<'tcx>(
         inv_params,
         ends: pre.index_info.ends,
         globals: pre.globals,
-        non_fn_globals,
         var_nodes: pre.var_nodes,
+        non_fn_globals,
+        locals_map,
+        locals_index_map,
     }
 }
 

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -128,14 +128,13 @@ pub type Solutions = IndexVec<Loc, HybridBitSet<Loc>>; // Send not implemented f
 
 #[derive(Debug)]
 pub struct AliasResults {
-    pub aliases: FxHashMap<DefId, FxHashSet<Local>>,
-    pub inv_params: FxHashMap<DefId, FxHashMap<Loc, FxHashSet<Local>>>,
-    pub ends: IndexVec<Loc, Loc>,
-    pub globals: FxHashMap<LocalDefId, Loc>,
-    pub var_nodes: FxHashMap<(LocalDefId, Local), LocNode>,
-    pub non_fn_globals: HybridBitSet<Loc>,
-    pub local_locs: FxHashMap<DefId, HybridBitSet<Loc>>,
-    pub index_locals: FxHashMap<DefId, FxHashMap<Loc, Local>>,
+    pub aliases: FxHashMap<DefId, FxHashSet<Local>>, // set of parameters that may alias each other
+    pub inv_params: FxHashMap<DefId, FxHashMap<Loc, FxHashSet<Local>>>, /* maps a location to the set of parameters that may point to it */
+    pub ends: IndexVec<Loc, Loc>, // maps global index to its end index
+    pub globals: FxHashMap<LocalDefId, Loc>, // maps a static item to the corresponding global index
+    pub var_nodes: FxHashMap<(LocalDefId, Local), LocNode>, /* maps (function, local) to the corresponding node */
+    pub non_fn_globals: HybridBitSet<Loc>, // set of global indexes of global variables
+    pub index_locals: FxHashMap<DefId, FxHashMap<Loc, Local>>, /* maps a global index to the corresponding local */
 }
 
 #[derive(Debug)]
@@ -571,7 +570,6 @@ pub fn compute_alias<'tcx>(
 ) -> AliasResults {
     let mut aliases: FxHashMap<_, FxHashSet<Local>> = FxHashMap::default();
     let mut inv_params: FxHashMap<_, FxHashMap<_, FxHashSet<Local>>> = FxHashMap::default();
-    let mut local_locs: FxHashMap<_, HybridBitSet<Loc>> = FxHashMap::default();
     let mut index_locals: FxHashMap<_, FxHashMap<Loc, Local>> = FxHashMap::default();
     let non_fn_globals = pre.non_fn_globals.iter().fold(
         HybridBitSet::new_empty(pre.index_info.len()),
@@ -595,7 +593,8 @@ pub fn compute_alias<'tcx>(
 
         for (local, decl) in body.local_decls.iter_enumerated() {
             let g_index = pre.var_nodes[&(local_def_id, local)].index;
-            locals_index.insert(g_index, local);
+            let g_index_end = pre.index_info.ends[g_index];
+            locals_index.extend((g_index..=g_index_end).map(|loc| (loc, local)));
 
             if (1..=*inputs).contains(&local.index()) {
                 let ty = decl.ty;
@@ -634,7 +633,6 @@ pub fn compute_alias<'tcx>(
 
         aliases.insert(*def_id, fun_alias);
         inv_params.insert(*def_id, inv_param);
-        local_locs.insert(*def_id, locals);
         index_locals.insert(*def_id, locals_index);
     }
 
@@ -645,7 +643,6 @@ pub fn compute_alias<'tcx>(
         globals: pre.globals,
         var_nodes: pre.var_nodes,
         non_fn_globals,
-        local_locs,
         index_locals,
     }
 }

--- a/src/may_analysis/analysis.rs
+++ b/src/may_analysis/analysis.rs
@@ -584,7 +584,7 @@ pub fn compute_alias<'tcx>(
         let local_def_id = some_or!(def_id.as_local(), continue);
         let mut params = vec![];
         let mut locals = HybridBitSet::new_empty(pre.index_info.len());
-        let mut locals_index = FxHashMap::default();
+        let mut index_local = FxHashMap::default();
 
         // Aliases of the function parameters
         let mut fun_alias = FxHashSet::default();
@@ -594,7 +594,7 @@ pub fn compute_alias<'tcx>(
         for (local, decl) in body.local_decls.iter_enumerated() {
             let g_index = pre.var_nodes[&(local_def_id, local)].index;
             let g_index_end = pre.index_info.ends[g_index];
-            locals_index.extend((g_index..=g_index_end).map(|loc| (loc, local)));
+            index_local.extend((g_index..=g_index_end).map(|loc| (loc, local)));
 
             if (1..=*inputs).contains(&local.index()) {
                 let ty = decl.ty;
@@ -633,7 +633,7 @@ pub fn compute_alias<'tcx>(
 
         aliases.insert(*def_id, fun_alias);
         inv_params.insert(*def_id, inv_param);
-        index_locals.insert(*def_id, locals_index);
+        index_locals.insert(*def_id, index_local);
     }
 
     AliasResults {


### PR DESCRIPTION
related kaist-plrg/nopcrat#8 

개선 사항
- C 함수 호출: side-effect 없는 함수들을 list에 추가, 해당 함수들은 CPure로 판단하였습니다.
- Intra 함수 호출: 함수 (및 해당 함수에서 호출하는 transitive한 callees) 에서 global variable에 쓰거나, effect가 있는 함수(CEffect, RustEffect, IntraEffect, 또는 Top)를 호출하는 경우, 해당 함수를 side-effect 있는 함수로 분류하였습니다.
- 함수가 암시적으로 non-null pointer만 인자로 받는 경우, nullable parameter로 인한 exclude를 반영하지 않도록 하였습니다.
  - write set에 반영되는 첫 write에서 p -> Top 인지 여부를 체크하고, 이를 저장하기 위해 state에 `MustLocalSet`, `nonnulls`를 추가했습니다.
  - nullable detection으로 인한 exclude를 구분하기 위해 null exclude set을 추가하였습니다.
  - x가 암시적으로 non-null인 parameter로 판단되는 경우, null exclude에 x가 포함되어 있더라도 exclude하지 않습니다. 


[테스트 결과](https://docs.google.com/spreadsheets/d/1YIqOFNe57bUTBEXOW9HzT18_DG8DP8sYc4CAarGs2mI/edit?usp=sharing)

- Negatives: nullable detection 구현으로 인해 output parameter -> unremovable parameter로 변경된 parameters.
- Positives: nullable detection 구현으로 인해 unremovable parameter -> output parameter 로 변경된 parameters.
  - 이 PR로 1개의 FP 추가됨 (fd_read_body). kaist-plrg/crat#4 
- Diffs: master branch와 비교했을 때 Negative -> Positive로 변경된 parameters. (기존 논문 결과에서는 모두 positive)